### PR TITLE
Add ShellCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ example on the `InsertLeave` or `TextChanged` events.
 
 - [Languagetool][5]
 - [Vale][8]
+- [ShellCheck][10]
 
 
 ## Custom Linters
@@ -172,3 +173,4 @@ export interface Diagnostic {
 [7]: https://github.com/iamcco/diagnostic-languageserver
 [8]: https://github.com/errata-ai/vale
 [9]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#diagnostic
+[10]: https://www.shellcheck.net/

--- a/lua/lint/linters/shellcheck.lua
+++ b/lua/lint/linters/shellcheck.lua
@@ -1,0 +1,37 @@
+local severities = {
+  error = vim.lsp.protocol.DiagnosticSeverity.Error,
+  warning = vim.lsp.protocol.DiagnosticSeverity.Warning,
+  info = vim.lsp.protocol.DiagnosticSeverity.Information,
+  style = vim.lsp.protocol.DiagnosticSeverity.Hint,
+}
+
+return {
+  cmd = 'shellcheck',
+  stdin = true,
+  args = {
+    '--format', 'json',
+    '-',
+  },
+  parser = function(output, bufnr)
+    local decoded = vim.fn.json_decode(output)
+    local diagnostics = {}
+    for _, item in ipairs(decoded or {}) do
+      table.insert(diagnostics, {
+        range = {
+          ['start'] = {
+            line = item.line - 1,
+            character = item.column - 1,
+          },
+          ['end'] = {
+            line = item.endLine - 1,
+            character = item.endColumn - 1,
+          },
+        },
+        code = item.code,
+        severity = assert(severities[item.level], 'missing mapping for severity ' .. item.level),
+        message = item.message,
+      })
+    end
+    return diagnostics
+  end,
+}


### PR DESCRIPTION
This PR adds ShellCheck to the list of available linters

The JSON object also has a `fix` key that contains the information necessary to do automatic fixes but AFAIK there's no way to configure client-side code actions.

Thanks for the cool plugin! Works really well :)