### PR TITLE
feat: Add Mypy linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ example on the `InsertLeave` or `TextChanged` events.
 - [Languagetool][5]
 - [Vale][8]
 - [ShellCheck][10]
+- [Mypy][11]
 
 
 ## Custom Linters
@@ -174,3 +175,4 @@ export interface Diagnostic {
 [8]: https://github.com/errata-ai/vale
 [9]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#diagnostic
 [10]: https://www.shellcheck.net/
+[11]: http://mypy-lang.org/

--- a/lua/lint/linters/mypy.lua
+++ b/lua/lint/linters/mypy.lua
@@ -1,0 +1,41 @@
+local severities = {
+  error = vim.lsp.protocol.DiagnosticSeverity.Error,
+  warning = vim.lsp.protocol.DiagnosticSeverity.Warning,
+  note = vim.lsp.protocol.DiagnosticSeverity.Hint,
+}
+
+-- path/to/file:line:col: severity: message
+local pattern  = "([^:]+):(%d+):(%d+): (%a+): (.*)"
+
+return {
+  cmd = 'mypy',
+  stdin = false,
+  args = {'--show-column-numbers'},
+  parser = function(output, bufnr)
+    local result = vim.fn.split(output, "\n")
+    -- Remove the last message 'found n errors... / Success: no issues ...'
+    table.remove(result)
+    local diagnostics = {}
+    local buf_file = vim.fn.fnamemodify(vim.fn.bufname(bufnr), ':~:.')
+
+    for _, message in ipairs(result) do
+      local file, lineno, offset, severity, msg = string.match(message, pattern)
+      -- We should only report the errors found in the current file as mypy can
+      -- follow the `imports` and report the errors from those files as well.
+      if file == buf_file then
+        lineno = tonumber(lineno or 1) - 1
+        offset = tonumber(offset or 1) - 1
+        table.insert(diagnostics, {
+          source = 'mypy',
+          range = {
+            ['start'] = {line = lineno, character = offset},
+            ['end'] = {line = lineno, character = offset + 1}
+          },
+          message = msg,
+          severity = assert(severities[severity], 'missing mapping for severity ' .. severity),
+        })
+      end
+    end
+    return diagnostics
+  end
+}


### PR DESCRIPTION
Hello, awesome plugin. I was messing around with it and added the two linters: `mypy` and `flake8` for Python files. I will submit another PR for `flake8`.

`mypy` does not have the support to take input from stdin and so we have to use pattern matching to extract the out information from the output. I added a helper function `split` which can help in that. I put it in the `util` module as I believe it could be useful for other linters as well.