### PR TITLE
Add HTML Tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ example on the `InsertLeave` or `TextChanged` events.
 - [Vale][8]
 - [ShellCheck][10]
 - [Mypy][11]
+- [HTML Tidy][12]
 
 
 ## Custom Linters
@@ -176,3 +177,4 @@ export interface Diagnostic {
 [9]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#diagnostic
 [10]: https://www.shellcheck.net/
 [11]: http://mypy-lang.org/
+[12]: https://www.html-tidy.org/

--- a/lua/lint/linters/tidy.lua
+++ b/lua/lint/linters/tidy.lua
@@ -1,0 +1,50 @@
+local severities = {
+  Info = vim.lsp.protocol.DiagnosticSeverity.Information,
+  Warning = vim.lsp.protocol.DiagnosticSeverity.Warning,
+  Config = vim.lsp.protocol.DiagnosticSeverity.Error,
+  Access = vim.lsp.protocol.DiagnosticSeverity.Information,
+  Error = vim.lsp.protocol.DiagnosticSeverity.Error,
+  Document = vim.lsp.protocol.DiagnosticSeverity.Error,
+  Panic = vim.lsp.protocol.DiagnosticSeverity.Error,
+  Summary = vim.lsp.protocol.DiagnosticSeverity.Information,
+  Information = vim.lsp.protocol.DiagnosticSeverity.Information,
+  Footnote = vim.lsp.protocol.DiagnosticSeverity.Information,
+}
+
+local pattern = 'line (%d+) column (%d+) %- (%a+): (.+)'
+
+return {
+  cmd = 'tidy',
+  stdin = true,
+  stream = 'stderr',
+  args = {
+    '-quiet',
+    '-errors',
+    '-language', 'en',
+    '--gnu-emacs', 'yes',
+  },
+  parser = function(output, bufnr)
+    local diagnostics = {}
+    for item in vim.gsplit(output, '\n') do
+      local line, column, severity, message = string.match(item, pattern)
+      if line and column then
+        table.insert(diagnostics, {
+          source = 'tidy',
+          range = {
+            ['start'] = {
+              line = tonumber(line) - 1,
+              character = tonumber(column) - 1,
+            },
+            ['end'] = {
+              line = tonumber(line) - 1,
+              character = tonumber(column),
+            },
+          },
+          message = message,
+          severity = assert(severities[severity], 'missing mapping for severity ' .. severity),
+        })
+      end
+    end
+    return diagnostics
+  end,
+}


### PR DESCRIPTION
This PR adds HTML Tidy to the list of available linters

Since Tidy only reports a line and a column number, I chose to leave an offset of 1 like in #7