### PR TITLE
feat: Add Flake8 linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ example on the `InsertLeave` or `TextChanged` events.
 - [ShellCheck][10]
 - [Mypy][11]
 - [HTML Tidy][12]
+- [Flake8][13]
 
 
 ## Custom Linters
@@ -178,3 +179,4 @@ export interface Diagnostic {
 [10]: https://www.shellcheck.net/
 [11]: http://mypy-lang.org/
 [12]: https://www.html-tidy.org/
+[13]: https://flake8.pycqa.org/

--- a/lua/lint/linters/flake8.lua
+++ b/lua/lint/linters/flake8.lua
@@ -1,0 +1,29 @@
+-- path/to/file:line:col: code message
+local pattern = "[^:]+:(%d+):(%d+): (%w+) (.*)"
+
+return {
+  cmd = 'flake8',
+  stdin = false,
+  args = {},
+  parser = function(output, _)
+    local result = vim.fn.split(output, "\n")
+    local diagnostics = {}
+
+    for _, message in ipairs(result) do
+      local lineno, offset, code, msg = string.match(message, pattern)
+      lineno = tonumber(lineno or 1) - 1
+      offset = tonumber(offset or 1) - 1
+      table.insert(diagnostics, {
+        source = 'flake8',
+        code = code,
+        range = {
+          ['start'] = {line = lineno, character = offset},
+          ['end'] = {line = lineno, character = offset + 1}
+        },
+        message = code .. ' ' .. msg,
+        severity = vim.lsp.protocol.DiagnosticSeverity.Error,
+      })
+    end
+    return diagnostics
+  end
+}


### PR DESCRIPTION
As mentioned in my previous pull request, adding the `flake8` linter configuration for Python files.

#### Note:

`flake8` does take input from stdin but when I tried to configure it as such it was giving me false-positives. I tried running `flake8` directly from the command line and it was not giving me those errors there. There seems to be some issue as to how this plugin works with stdin linters.

**Conditions tested on:**
- Running only `flake8` for Python file in neovim using `nvim-lint` (gives false-positive)
- Running `flake8` from command line (does not give false-positive)
- Running `flake8` from command line through stdin (`cat <file> | flake8 -`) (does not give false-positive)
- Running `flake8` from neovim command prompt (`:%!flake8 -`) (does not give false-positive)

Also, `flake8` has its own set of violation codes namely ('C', 'E', 'F', 'W'): https://flake8.pycqa.org/en/latest/user/violations.html#selecting-violations-with-flake8
> Flake8 has a default list of violation classes that we use. This list is:
>- C90: All C90 class violations are reported when the user specifies flake8 --max-complexity
>- E: All E class violations are “errors” reported by pycodestyle
>- F: All F class violations are reported by pyflakes
>- W: All W class violations are “warnings” reported by pycodestyle

For now, I have added all of them in the `Error` severity (same as that from [`efm-langserver`](https://github.com/mattn/efm-langserver))