### PR TITLE
Add staticcheck linter for go

### DIFF
--- a/lua/lint/linters/staticcheck.lua
+++ b/lua/lint/linters/staticcheck.lua
@@ -1,0 +1,36 @@
+local severities = {
+  error = vim.lsp.protocol.DiagnosticSeverity.Error,
+  warning = vim.lsp.protocol.DiagnosticSeverity.Warning,
+  ignored = vim.lsp.protocol.DiagnosticSeverity.Information,
+}
+
+return {
+  cmd = 'staticcheck',
+  stdin = true,
+  args = {
+    '-f', 'json',
+  },
+  parser = function(output, bufnr)
+    local result = vim.fn.split(output, "\n")
+    local diagnostics = {}
+    for _, message in ipairs(result) do
+      local decoded = vim.fn.json_decode(message)
+        table.insert(diagnostics, {
+          range = {
+            ['start'] = {
+              line = decoded.location.line - 1,
+              character = decoded.location.column - 1,
+            },
+            ['end'] = {
+              line = decoded["end"]["line"] - 1,
+              character = decoded["end"]["column"] - 1,
+            },
+          },
+          code = decoded.code,
+          severity = assert(severities[decoded.severity], 'missing mapping for severity ' .. decoded.severity),
+          message = decoded.message,
+        })
+    end
+    return diagnostics
+  end,
+}


### PR DESCRIPTION
This still has two problems:
1. Just like the `shellcheck` linter, there is the message "Linter exited with code 1" after linting, even though it seems to work correctly.
1. It currently fails, unless I hardcode the values for end line/character, with
> Linter definition must have a `cmd` set: "vim.lua:129: .../packer/start/nvim-lint/lua/lint/linters/staticcheck.lua:25: '<name>' expected near 'end'

I guess that has to do with the keyword `end` in the json output.

Edit: Fixed issue two by reading more lua documentation.