### PR TITLE
Add linter property to ignore the exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ require('lint').linters.your_linter_name = {
   stdin = true -- or false if it doesn't support content input via stdin. In that case the filename is automatically added to the arguments.
   args = {}, -- list of arguments. Can contain functions with zero arguments that will be evaluated once the linter is used.
   stream = nil, -- ('stdout' | 'stderr') configure the stream to which the linter outputs the linting result.
+  ignore_exitcode = false, -- set this to true if the linter exits with a code != 0 and that's considered normal.
   parser = your_parse_function
 }
 ```

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -107,7 +107,7 @@ function M.lint(linter, client_id)
     stdout:close()
     stderr:close()
     handle:close()
-    if code ~= 0 then
+    if code ~= 0 and not linter.ignore_exitcode then
       print('Linter exited with code', code)
     end
   end)

--- a/lua/lint/linters/shellcheck.lua
+++ b/lua/lint/linters/shellcheck.lua
@@ -12,6 +12,7 @@ return {
     '--format', 'json',
     '-',
   },
+  ignore_exitcode = true,
   parser = function(output, bufnr)
     local decoded = vim.fn.json_decode(output)
     local diagnostics = {}

--- a/lua/lint/linters/staticcheck.lua
+++ b/lua/lint/linters/staticcheck.lua
@@ -10,6 +10,7 @@ return {
   args = {
     '-f', 'json',
   },
+  ignore_exitcode = true,
   parser = function(output, bufnr)
     local result = vim.fn.split(output, "\n")
     local diagnostics = {}


### PR DESCRIPTION
Set to true for shellcheck and staticcheck.

As mentioned in https://github.com/mfussenegger/nvim-lint/pull/11.