### PR TITLE
Ensure consistent Mypy output regardless of project configuration

### DIFF
--- a/lua/lint/linters/mypy.lua
+++ b/lua/lint/linters/mypy.lua
@@ -12,7 +12,11 @@ return {
   stdin = false,
   args = {
     '--show-column-numbers',
+    '--hide-error-codes',
+    '--hide-error-context',
+    '--no-color-output',
     '--no-error-summary',
+    '--no-pretty',
   },
   parser = function(output, bufnr)
     local result = vim.fn.split(output, "\n")

--- a/lua/lint/linters/mypy.lua
+++ b/lua/lint/linters/mypy.lua
@@ -10,11 +10,12 @@ local pattern  = "([^:]+):(%d+):(%d+): (%a+): (.*)"
 return {
   cmd = 'mypy',
   stdin = false,
-  args = {'--show-column-numbers'},
+  args = {
+    '--show-column-numbers',
+    '--no-error-summary',
+  },
   parser = function(output, bufnr)
     local result = vim.fn.split(output, "\n")
-    -- Remove the last message 'found n errors... / Success: no issues ...'
-    table.remove(result)
     local diagnostics = {}
     local buf_file = vim.fn.fnamemodify(vim.fn.bufname(bufnr), ':~:.')
 


### PR DESCRIPTION
This ensure a consistent output from Mypy regardless of what might be in a project's `mypy.ini` (or similar) that could alter the output format causing parsing errors.

It also removes the need for removing the "found n errors... / Success: no issues ..." message because it's not printed to begin with.