### PR TITLE
Add golangci-lint linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ example on the `InsertLeave` or `TextChanged` events.
 - [Flake8][13]
 - [Revive][14]
 - [Pylint][15]
+- [Golangci-lint][16]
 
 
 ## Custom Linters
@@ -184,3 +185,4 @@ export interface Diagnostic {
 [13]: https://flake8.pycqa.org/
 [14]: https://github.com/mgechev/revive
 [15]: https://pylint.org/
+[16]: https://golangci-lint.run/

--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -1,0 +1,50 @@
+local severities = {
+  error = vim.lsp.protocol.DiagnosticSeverity.Error,
+  warning = vim.lsp.protocol.DiagnosticSeverity.Warning,
+  refactor = vim.lsp.protocol.DiagnosticSeverity.Information,
+  convention = vim.lsp.protocol.DiagnosticSeverity.Hint,
+}
+
+return {
+  cmd = 'golangci-lint',
+  stdin = true,
+  args = {
+    'run',
+    '--out-format',
+    'json',
+  },
+  stream = 'stdout',
+  ignore_exitcode = true,
+  parser = function(output, bufnr)
+    if output == '' then
+      return {}
+    end
+    local decoded = vim.fn.json_decode(output)
+    if decoded["Issues"] == nil or type(decoded["Issues"]) == 'userdata' then
+      return {}
+    end
+
+    local diagnostics = {}
+    for _, item in ipairs(decoded["Issues"]) do
+      local sv = vim.lsp.protocol.DiagnosticSeverity.Warning
+      if severities[item.Severity] ~= nil then
+        sv = severities[item.Severity]
+      end
+      table.insert(diagnostics, {
+        range = {
+          ['start'] = {
+            line = item.Pos.Line - 1,
+            character = item.Pos.Column,
+          },
+          ['end'] = {
+            line = item.Pos.Line - 1,
+            character = item.Pos.Column + 1,
+          },
+        },
+        severity = sv,
+        message = item.Text,
+      })
+    end
+    return diagnostics
+  end
+}

--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -34,11 +34,11 @@ return {
         range = {
           ['start'] = {
             line = item.Pos.Line - 1,
-            character = item.Pos.Column,
+            character = item.Pos.Column - 1,
           },
           ['end'] = {
             line = item.Pos.Line - 1,
-            character = item.Pos.Column + 1,
+            character = item.Pos.Column - 1,
           },
         },
         severity = sv,


### PR DESCRIPTION
Add `golangci-lint` linter. [golangci-lint](https://golangci-lint.run/) is a linter for Go that aggregate other popular Go linter together in one tool.