### PR TITLE
Tell golangci to use the current buffer only

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -12,6 +12,10 @@ return {
     'run',
     '--out-format',
     'json',
+    function()
+      local bufnr = vim.api.nvim_get_current_buf()
+      return vim.api.nvim_buf_get_name(bufnr)
+    end
   },
   stream = 'stdout',
   ignore_exitcode = true,


### PR DESCRIPTION
If no path is passed to golangci-lint, it will run on the current
folder, yielding many different diagnostics which are not related to the
current file.

The problem is that those are still going to be displayed on the current
buffer, using their position in their files. This lead to a meaningless
superposition of all diagnostics on the current file.

The present change fixes that by scoping the linter run on the
currently opened file.