### PR TITLE
Tell golangci to use the current buffer only

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -26,17 +26,18 @@ return {
 
     local diagnostics = {}
     for _, item in ipairs(decoded["Issues"]) do
-      local sv = vim.lsp.protocol.DiagnosticSeverity.Warning
-      if severities[item.Severity] ~= nil then
-        sv = severities[item.Severity]
-      end
-      table.insert(diagnostics, {
-        range = {
-          ['start'] = {
-            line = item.Pos.Line - 1,
-            character = item.Pos.Column - 1,
-          },
-          ['end'] = {
+      local curfile = vim.api.nvim_buf_get_name(bufnr)
+      local lintedfile = vim.fn.getcwd() .. "/" .. item.Pos.Filename
+      if curfile == lintedfile then
+        -- only publish if those are the current file diagnostics
+        local sv = severities[item.Severity] or severities.warning
+        table.insert(diagnostics, {
+          range = {
+            ['start'] = {
+              line = item.Pos.Line - 1,
+              character = item.Pos.Column - 1,
+            },
+            ['end'] = {
             line = item.Pos.Line - 1,
             character = item.Pos.Column - 1,
           },
@@ -45,6 +46,7 @@ return {
         message = item.Text,
       })
     end
-    return diagnostics
   end
+  return diagnostics
+end
 }


### PR DESCRIPTION
Hello! I Great idea btw to wire the linters to the lsp handlers 🎉 !  

I  spotted 👇  while giving it a try for Go, so here is a fix. 

If no path is passed to golangci-lint, it will run on the current
folder, yielding many different diagnostics which are not related to the
current file.

The problem is that those are still going to be displayed on the current
buffer, using their position in their files. This lead to a meaningless
superposition of all diagnostics on the current file.

Forcing Golangci to run only on the current file will yield false positives, because some symbols will be missing for the linters to parse. So, this code just throw away the diagnostics that do not concern the current file. 

That's rather crude, but it works.  