### PR TITLE
Fixed golang revive linters matching pattern

### DIFF
--- a/lua/lint/linters/revive.lua
+++ b/lua/lint/linters/revive.lua
@@ -1,5 +1,5 @@
 -- path/to/file:line:col: code message
-local pattern = "[^:]+:(%d+):(%d+): (%w+) (.*)"
+local pattern = "[^:]+:(%d+):(%d+): (.*) (.*)"
 
 return {
   cmd = 'revive',

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -43,6 +43,9 @@ function M.from_pattern(pattern, diagnostic_skeleton)
 
     for _, message in ipairs(result) do
       local lineno, offset, code, msg = string.match(message, pattern)
+      if code == nil or code == "" or msg == nil or msg == "" then
+        error("The provided linter pattern failed to match on the linters output.")
+      end
       lineno = tonumber(lineno or 1) - 1
       offset = tonumber(offset or 1) - 1
       local d = vim.deepcopy(diagnostic_skeleton)


### PR DESCRIPTION
`./path/to/file/main.go:15:2: don't use ALL_CAPS in Go names; use CamelCase` This error was causing the pattern matching for revive to fail.
