### PR TITLE
Feature: Add cppcheck support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Other dedicated linters that are built-in are:
 | [Golangci-lint][16] | `golangcilint`  |
 | Ruby                | `ruby`          |
 | [Inko][17]          | `inko`          |
+| cppcheck            | `cppcheck`      |
 
 
 ## Custom Linters

--- a/lua/lint/linters/cppcheck.lua
+++ b/lua/lint/linters/cppcheck.lua
@@ -1,0 +1,41 @@
+local cppcheck_pattern = [[([^:]*):(%d*):(%d*): %[([^%]\]*)%] ([^:]*): (.*)]]
+return {
+  cmd = 'cppcheck',
+  stdin = false,
+  args = {
+    '--enable=warning,style,performance,information', '--language=c++',
+    '--project=build/compile_commands.json', '--inline-suppr', '--quiet',
+    '--cppcheck-build-dir=build', '--template={file}:{line}:{column}: [{id}] {severity}: {message}'
+  },
+  stream = 'stderr',
+  parser = function(output, bufnr)
+    local buffer_path = vim.api.nvim_buf_get_name(bufnr)
+    local diagnostics = {}
+    for line in vim.gsplit(output, '\n') do
+      for file, lineno, colno, id, severity, msg in string.gmatch(line, cppcheck_pattern) do
+        if file == buffer_path then
+          local diagnostic = {}
+          diagnostic.range = {}
+          local line_num = tonumber(lineno)
+          local col_num = tonumber(colno)
+          local range = {line = line_num - 1, character = col_num - 1}
+          diagnostic.range.start = range
+          diagnostic.range['end'] = range
+          if severity == 'style' or severity == 'information' then
+            diagnostic.severity = vim.lsp.protocol.DiagnosticSeverity.Information
+          elseif severity == 'warning' or severity == 'performance' then
+            diagnostic.severity = vim.lsp.protocol.DiagnosticSeverity.Warning
+          elseif severity == 'error' then
+            diagnostic.severity = vim.lsp.protocol.DiagnosticSeverity.Error
+          end
+
+          diagnostic.source = 'cppcheck(' .. id .. ')'
+          diagnostic.message = msg
+          diagnostics[#diagnostics + 1] = diagnostic
+        end
+      end
+    end
+
+    return diagnostics
+  end
+}


### PR DESCRIPTION
This PR adds initial, somewhat hacky support for [cppcheck](http://cppcheck.sourceforge.net/).

The hacky parts are:
1. It currently hardcodes the presence of a build directory named `build` and a `compile_commands.json` in that directory.
2. It runs `cppcheck` on the whole project and filters out diagnostics relevant to the current file.
3. It probably doesn't work right if a file has been modified but not saved.

This is very similar to the approach `ALE` takes, but I think we could do better by (1) more robust `compile_commands.json` detection and (2) maybe somehow parsing compile args from `compile_commands.json` ourselves to allow only running `cppcheck` on the currently relevant file (the tool is obnoxious and will either run on the whole project with compile args from a `compile_commands.json` file, or specific files with manually specified args).

Still, this has been a useful starting point for my use, so it could be worth adding in its current form.