### PR TITLE
Add luacheck support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Other dedicated linters that are built-in are:
 | [Inko][17]          | `inko`         |
 | cppcheck            | `cppcheck`     |
 | [codespell][18]     | `codespell`    |
+| [luacheck][19]      | `luacheck`     |
 
 
 ## Custom Linters
@@ -223,3 +224,4 @@ export interface Diagnostic {
 [16]: https://golangci-lint.run/
 [17]: https://inko-lang.org/
 [18]: https://github.com/codespell-project/codespell
+[19]: https://github.com/mpeterv/luacheck

--- a/lua/lint/linters/luacheck.lua
+++ b/lua/lint/linters/luacheck.lua
@@ -1,0 +1,41 @@
+local severities = {
+    W = vim.lsp.protocol.DiagnosticSeverity.Warning,
+    E = vim.lsp.protocol.DiagnosticSeverity.Error
+}
+
+local pattern = '[^:]+:(%d+):(%d+)-(%d+): %((%a)(%d+)%) (.*)'
+
+return {
+    cmd = 'luacheck',
+    stdin = true,
+    args = {'--formatter', 'plain', '--codes', '--ranges', '-'},
+    ignore_exitcode = true,
+    parser = function(output, _)
+        local result = vim.fn.split(output, "\n")
+        local diagnostics = {}
+
+        for _, message in ipairs(result) do
+            local line, offs, offe, severity, code, desc =
+                string.match(message, pattern)
+
+            line = tonumber(line or 1) - 1
+            offs = tonumber(offs or 1) - 1
+            offe = tonumber(offe or 1)
+
+            table.insert(diagnostics, {
+                source = 'luacheck',
+                range = {
+                    ['start'] = {line = line, character = offs},
+                    ['end'] = {line = line, character = offe}
+                },
+                message = desc,
+                severity = assert(severities[severity],
+                                  'missing mapping for severity ' .. severity),
+                code = code
+            })
+        end
+
+        return diagnostics
+    end
+}
+


### PR DESCRIPTION
This PR adds [luacheck](https://github.com/mpeterv/luacheck) as a builtin linter for Lua.