### PR TITLE
Add chktex linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Other dedicated linters that are built-in are:
 | cppcheck            | `cppcheck`     |
 | [codespell][18]     | `codespell`    |
 | [luacheck][19]      | `luacheck`     |
+| [chktex][20]        | `chktex`       |
 
 
 ## Custom Linters
@@ -225,3 +226,4 @@ export interface Diagnostic {
 [17]: https://inko-lang.org/
 [18]: https://github.com/codespell-project/codespell
 [19]: https://github.com/mpeterv/luacheck
+[20]: https://www.nongnu.org/chktex

--- a/lua/lint/linters/chktex.lua
+++ b/lua/lint/linters/chktex.lua
@@ -1,0 +1,37 @@
+local pattern = '(%d+):(%d+):(%d+):(.+):(%d+):(.*)'
+local severities = {
+    Error = vim.lsp.protocol.DiagnosticSeverity.Error,
+    Warning = vim.lsp.protocol.DiagnosticSeverity.Warning,
+    Message = vim.lsp.protocol.DiagnosticSeverity.Information
+}
+
+return {
+    cmd = 'chktex',
+    stdin = true,
+    args = {'-v0', '-I0', '-s', ':', '-f', '%l%b%c%b%d%b%k%b%n%b%m%b%b%b'},
+    parser = function(output, _)
+        local result = vim.fn.split(output, ":::")
+        local diagnostics = {}
+
+        for _, line in ipairs(result) do
+            local lineno, off, d, sev, code, desc = string.match(line, pattern)
+
+            lineno = tonumber(lineno or 1) - 1
+            off = tonumber(off or 1) - 1
+            d = tonumber(d or 1)
+            table.insert(diagnostics, {
+                source = 'luacheck',
+                range = {
+                    ['start'] = {line = lineno, character = off},
+                    ['end'] = {line = lineno, character = off + d}
+                },
+                message = desc,
+                severity = assert(severities[sev],
+                                  'missing mapping for severity ' .. sev),
+                code = code
+            })
+        end
+        return diagnostics
+
+    end
+}


### PR DESCRIPTION
This PR adds [chktex](https://www.nongnu.org/chktex) as a builtin linter for TeX files.