### PR TITLE
luacheck: add vim global when checking runtime files

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,20 @@ require('lint').linters.your_linter_name = {
 
 Instead of declaring the linter as a table, you can also declare it as a
 function which returns the linter table in case you want to dynamically
-generate some of the properties.
+generate some of the properties. This function is passed the buffer number of
+the buffer being linted:
+
+```lua
+return function(bufnr)
+  local cmd = ...; -- set command based on current buffer
+  local args = ...; -- set args based on current buffer
+  return {
+    cmd = cmd,
+    args = args,
+    ...
+  }
+end
+```
 
 `your_parse_function` can be a function which takes two arguments:
 

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -106,7 +106,7 @@ function M.lint(linter, client_id)
   local args = {}
   local bufnr = api.nvim_get_current_buf()
   if type(linter) == "function" then
-    linter = linter()
+    linter = linter(bufnr)
   end
   if linter.args then
     vim.list_extend(args, vim.tbl_map(eval_fn_or_id, linter.args))

--- a/lua/lint/linters/luacheck.lua
+++ b/lua/lint/linters/luacheck.lua
@@ -5,9 +5,8 @@ local severities = {
 
 local pattern = '[^:]+:(%d+):(%d+)-(%d+): %((%a)(%d+)%) (.*)'
 
-return function()
+return function(bufnr)
     local args = {'--formatter', 'plain', '--codes', '--ranges', '-'}
-    local bufnr = vim.api.nvim_get_current_buf()
     local filename = vim.api.nvim_buf_get_name(bufnr)
     for path in vim.gsplit(vim.o.runtimepath, ',') do
         if filename:find('^' .. path) then

--- a/lua/lint/linters/luacheck.lua
+++ b/lua/lint/linters/luacheck.lua
@@ -5,37 +5,50 @@ local severities = {
 
 local pattern = '[^:]+:(%d+):(%d+)-(%d+): %((%a)(%d+)%) (.*)'
 
-return {
-    cmd = 'luacheck',
-    stdin = true,
-    args = {'--formatter', 'plain', '--codes', '--ranges', '-'},
-    ignore_exitcode = true,
-    parser = function(output, _)
-        local result = vim.fn.split(output, "\n")
-        local diagnostics = {}
-
-        for _, message in ipairs(result) do
-            local line, offs, offe, severity, code, desc =
-                string.match(message, pattern)
-
-            line = tonumber(line or 1) - 1
-            offs = tonumber(offs or 1) - 1
-            offe = tonumber(offe or 1)
-
-            table.insert(diagnostics, {
-                source = 'luacheck',
-                range = {
-                    ['start'] = {line = line, character = offs},
-                    ['end'] = {line = line, character = offe}
-                },
-                message = desc,
-                severity = assert(severities[severity],
-                                  'missing mapping for severity ' .. severity),
-                code = code
-            })
+return function()
+    local args = {'--formatter', 'plain', '--codes', '--ranges', '-'}
+    local bufnr = vim.api.nvim_get_current_buf()
+    local filename = vim.api.nvim_buf_get_name(bufnr)
+    for path in vim.gsplit(vim.o.runtimepath, ',') do
+        if filename:find('^' .. path) then
+            table.insert(args, '--read-globals')
+            table.insert(args, 'vim')
+            break
         end
-
-        return diagnostics
     end
-}
+
+    return {
+        cmd = 'luacheck',
+        stdin = true,
+        args = args,
+        ignore_exitcode = true,
+        parser = function(output, _)
+            local result = vim.fn.split(output, "\n")
+            local diagnostics = {}
+
+            for _, message in ipairs(result) do
+                local line, offs, offe, severity, code, desc =
+                    string.match(message, pattern)
+
+                line = tonumber(line or 1) - 1
+                offs = tonumber(offs or 1) - 1
+                offe = tonumber(offe or 1)
+
+                table.insert(diagnostics, {
+                    source = 'luacheck',
+                    range = {
+                        ['start'] = {line = line, character = offs},
+                        ['end'] = {line = line, character = offe}
+                    },
+                    message = desc,
+                    severity = assert(severities[severity],
+                                      'missing mapping for severity ' .. severity),
+                    code = code
+                })
+            end
+
+            return diagnostics
+        end
+    }
+end
 


### PR DESCRIPTION
If the current buffer is modifying a Lua file found underneath an entry
in &runtimepath then add a read-only global 'vim'.

This suppresses the "undefined value" warnings in Lua files used from
Neovim.
