### PR TITLE
Refactor from_pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The function allows to parse the linter's output using a lua regex pattern.
 - groups: The groups specified by the pattern
 
 ``` lua
-groups = {"lineno", "message", ("colno" | ("colbeg", "colend")), ["code"], ["codeDesc"], ["file"], ["severity"]}
+groups = {"line", "message", "start_col", ["end_col"], ["code"], ["code_desc"], ["file"], ["severity"]}
 ```
 
 - severity: A mapping from severity codes to diagnostic codes

--- a/README.md
+++ b/README.md
@@ -127,15 +127,34 @@ The function takes a single argument which is the `errorformat`.
 ### from_pattern
 
 ```lua
-parser = require('lint.parser').from_pattern(pattern, skeleton)
+parser = require('lint.parser').from_pattern(pattern, groups, severity_map, defaults)
 ```
 
-The function takes two arguments. The first is a lua pattern that must match
-four groups in order: line number, offset, code and message.
+The function allows to parse the linter's output using a lua regex pattern.
 
-The second argument is a skeleton used to create each diagnostic. This can be
-used to provide default values - for example to set a `severity`.
+- pattern: The regex pattern applied on each line of the output
+- groups: The groups specified by the pattern
 
+``` lua
+groups = {"lineno", "message", ("colno" | ("colbeg", "colend")), ["code"], ["codeDesc"], ["file"], ["severity"]}
+```
+
+- severity: A mapping from severity codes to diagnostic codes
+
+``` lua
+default_severity = {
+['error'] = vim.lsp.protocol.DiagnosticSeverity.Error,
+['warning'] = vim.lsp.protocol.DiagnosticSeverity.Warning,
+['information'] = vim.lsp.protocol.DiagnosticSeverity.Information,
+['hint'] = vim.lsp.protocol.DiagnosticSeverity.Hint,
+}
+```
+
+- defaults: The defaults diagnostic values
+
+``` lua
+defaults = {["source"] = "mylint-name"}
+```
 
 <details>
   <summary>Diagnostic interface description</summary>

--- a/lua/lint/linters/chktex.lua
+++ b/lua/lint/linters/chktex.lua
@@ -20,7 +20,7 @@ return {
             off = tonumber(off or 1) - 1
             d = tonumber(d or 1)
             table.insert(diagnostics, {
-                source = 'luacheck',
+                source = 'chktex',
                 range = {
                     ['start'] = {line = lineno, character = off},
                     ['end'] = {line = lineno, character = off + d}

--- a/lua/lint/linters/clangtidy.lua
+++ b/lua/lint/linters/clangtidy.lua
@@ -1,5 +1,5 @@
 local pattern = [[([^:]*):(%d+):(%d+): (%w+): ([^[]+)]]
-local groups = { 'file', 'lineno', 'colno', 'severity', 'message' }
+local groups = { 'file', 'line', 'start_col', 'severity', 'message' }
 
 return {
   cmd = 'clang-tidy',

--- a/lua/lint/linters/clangtidy.lua
+++ b/lua/lint/linters/clangtidy.lua
@@ -1,14 +1,9 @@
 local pattern = [[([^:]*):(%d+):(%d+): (%w+): ([^[]+)]]
 local groups = { 'file', 'lineno', 'colno', 'severity', 'message' }
 
-local severities = {
-  error = vim.lsp.protocol.DiagnosticSeverity.Error,
-  warning = vim.lsp.protocol.DiagnosticSeverity.Warning,
-}
-
 return {
   cmd = 'clang-tidy',
   stdin = false,
   args = { '--quiet' },
-  parser = require('lint.parser').from_pattern(pattern, groups),
+  parser = require('lint.parser').from_pattern(pattern, groups, nil, { ['source'] = 'clang-tidy' }),
 }

--- a/lua/lint/linters/clangtidy.lua
+++ b/lua/lint/linters/clangtidy.lua
@@ -1,4 +1,5 @@
 local pattern = [[([^:]*):(%d+):(%d+): (%w+): ([^[]+)]]
+local groups = { 'file', 'lineno', 'colno', 'severity', 'message' }
 
 local severities = {
   error = vim.lsp.protocol.DiagnosticSeverity.Error,
@@ -6,34 +7,8 @@ local severities = {
 }
 
 return {
-  cmd = "clang-tidy",
+  cmd = 'clang-tidy',
   stdin = false,
-  args = { "--quiet" },
-  parser = function(output, bufnr)
-    local buffer_path = vim.api.nvim_buf_get_name(bufnr)
-    local diagnostics = {}
-
-    for line in vim.gsplit(output, "\n") do
-      for file, lineno, colno, severity, msg in line:gmatch(pattern) do
-        if file ~= buffer_path then
-          break
-        end
-
-        local range = {
-          line = tonumber(lineno) - 1,
-          character = tonumber(colno) - 1,
-        }
-        table.insert(diagnostics, {
-          range = {
-            ["start"] = range,
-            ["end"] = range,
-          },
-          severity = severities[severity] or severities.warning,
-          message = msg,
-        })
-      end
-    end
-
-    return diagnostics
-  end,
+  args = { '--quiet' },
+  parser = require('lint.parser').from_pattern(pattern, groups),
 }

--- a/lua/lint/linters/cppcheck.lua
+++ b/lua/lint/linters/cppcheck.lua
@@ -1,41 +1,25 @@
-local cppcheck_pattern = [[([^:]*):(%d*):(%d*): %[([^%]\]*)%] ([^:]*): (.*)]]
+local pattern = [[([^:]*):(%d*):(%d*): %[([^%]\]*)%] ([^:]*): (.*)]]
+local groups = { 'file', 'lineno', 'colno', 'code', 'severity', 'message' }
+local severity_map = {
+  ['error'] = vim.lsp.protocol.DiagnosticSeverity.Error,
+  ['warning'] = vim.lsp.protocol.DiagnosticSeverity.Warning,
+  ['performance'] = vim.lsp.protocol.DiagnosticSeverity.Warning,
+  ['style'] = vim.lsp.protocol.DiagnosticSeverity.Information,
+  ['information'] = vim.lsp.protocol.DiagnosticSeverity.Information,
+}
+
 return {
   cmd = 'cppcheck',
   stdin = false,
   args = {
-    '--enable=warning,style,performance,information', '--language=c++',
-    '--project=build/compile_commands.json', '--inline-suppr', '--quiet',
-    '--cppcheck-build-dir=build', '--template={file}:{line}:{column}: [{id}] {severity}: {message}'
+    '--enable=warning,style,performance,information',
+    '--language=c++',
+    '--project=build/compile_commands.json',
+    '--inline-suppr',
+    '--quiet',
+    '--cppcheck-build-dir=build',
+    '--template={file}:{line}:{column}: [{id}] {severity}: {message}',
   },
   stream = 'stderr',
-  parser = function(output, bufnr)
-    local buffer_path = vim.api.nvim_buf_get_name(bufnr)
-    local diagnostics = {}
-    for line in vim.gsplit(output, '\n') do
-      for file, lineno, colno, id, severity, msg in string.gmatch(line, cppcheck_pattern) do
-        if file == buffer_path then
-          local diagnostic = {}
-          diagnostic.range = {}
-          local line_num = tonumber(lineno)
-          local col_num = tonumber(colno)
-          local range = {line = line_num - 1, character = col_num - 1}
-          diagnostic.range.start = range
-          diagnostic.range['end'] = range
-          if severity == 'style' or severity == 'information' then
-            diagnostic.severity = vim.lsp.protocol.DiagnosticSeverity.Information
-          elseif severity == 'warning' or severity == 'performance' then
-            diagnostic.severity = vim.lsp.protocol.DiagnosticSeverity.Warning
-          elseif severity == 'error' then
-            diagnostic.severity = vim.lsp.protocol.DiagnosticSeverity.Error
-          end
-
-          diagnostic.source = 'cppcheck(' .. id .. ')'
-          diagnostic.message = msg
-          diagnostics[#diagnostics + 1] = diagnostic
-        end
-      end
-    end
-
-    return diagnostics
-  end
+  parser = require('lint.parser').from_pattern(pattern, groups, severity_map),
 }

--- a/lua/lint/linters/cppcheck.lua
+++ b/lua/lint/linters/cppcheck.lua
@@ -1,5 +1,5 @@
 local pattern = [[([^:]*):(%d*):(%d*): %[([^%]\]*)%] ([^:]*): (.*)]]
-local groups = { 'file', 'lineno', 'colno', 'code', 'severity', 'message' }
+local groups = { 'file', 'line', 'start_col', 'code', 'severity', 'message' }
 local severity_map = {
   ['error'] = vim.lsp.protocol.DiagnosticSeverity.Error,
   ['warning'] = vim.lsp.protocol.DiagnosticSeverity.Warning,

--- a/lua/lint/linters/cppcheck.lua
+++ b/lua/lint/linters/cppcheck.lua
@@ -21,5 +21,5 @@ return {
     '--template={file}:{line}:{column}: [{id}] {severity}: {message}',
   },
   stream = 'stderr',
-  parser = require('lint.parser').from_pattern(pattern, groups, severity_map),
+  parser = require('lint.parser').from_pattern(pattern, groups, severity_map, { ['source'] = 'cppcheck' }),
 }

--- a/lua/lint/linters/flake8.lua
+++ b/lua/lint/linters/flake8.lua
@@ -1,6 +1,6 @@
 -- path/to/file:line:col: code message
 local pattern = '[^:]+:(%d+):(%d+):(%w+):(.+)'
-local groups = { 'lineno', 'colno', 'code', 'message' }
+local groups = { 'line', 'start_col', 'code', 'message' }
 
 return {
   cmd = 'flake8',

--- a/lua/lint/linters/flake8.lua
+++ b/lua/lint/linters/flake8.lua
@@ -10,6 +10,6 @@ return {
     '--no-show-source',
   },
   parser = require('lint.parser').from_pattern(pattern, groups, nil, {
-    source = 'flake8',
+    ['source'] = 'flake8',
   }),
 }

--- a/lua/lint/linters/flake8.lua
+++ b/lua/lint/linters/flake8.lua
@@ -1,6 +1,6 @@
 -- path/to/file:line:col: code message
 local pattern = '[^:]+:(%d+):(%d+):(%w+):(.+)'
-local groups = { 'file', 'lineno', 'colno', 'code', 'message' }
+local groups = { 'lineno', 'colno', 'code', 'message' }
 
 return {
   cmd = 'flake8',

--- a/lua/lint/linters/flake8.lua
+++ b/lua/lint/linters/flake8.lua
@@ -1,5 +1,6 @@
 -- path/to/file:line:col: code message
-local pattern = "[^:]+:(%d+):(%d+):(%w+):(.+)"
+local pattern = '[^:]+:(%d+):(%d+):(%w+):(.+)'
+local groups = { 'file', 'lineno', 'colno', 'code', 'message' }
 
 return {
   cmd = 'flake8',
@@ -8,11 +9,7 @@ return {
     '--format=%(path)s:%(row)d:%(col)d:%(code)s:%(text)s',
     '--no-show-source',
   },
-  parser = require('lint.parser').from_pattern(
-    pattern,
-    {
-      source = 'flake8',
-      severity = vim.lsp.protocol.DiagnosticSeverity.Error
-    }
-  )
+  parser = require('lint.parser').from_pattern(pattern, groups, nil, {
+    source = 'flake8',
+  }),
 }

--- a/lua/lint/linters/luacheck.lua
+++ b/lua/lint/linters/luacheck.lua
@@ -1,5 +1,5 @@
 local pattern = '[^:]+:(%d+):(%d+)-(%d+): %((%a)(%d+)%) (.*)'
-local groups = { 'lineno', 'colbeg', 'colend', 'severity', 'code', 'message' }
+local groups = { 'line', 'start_col', 'end_col', 'severity', 'code', 'message' }
 local severities = {
   W = vim.lsp.protocol.DiagnosticSeverity.Warning,
   E = vim.lsp.protocol.DiagnosticSeverity.Error,

--- a/lua/lint/linters/luacheck.lua
+++ b/lua/lint/linters/luacheck.lua
@@ -1,41 +1,14 @@
-local severities = {
-    W = vim.lsp.protocol.DiagnosticSeverity.Warning,
-    E = vim.lsp.protocol.DiagnosticSeverity.Error
-}
-
 local pattern = '[^:]+:(%d+):(%d+)-(%d+): %((%a)(%d+)%) (.*)'
+local groups = { 'lineno', 'colbeg', 'colend', 'severity', 'code', 'message' }
+local severities = {
+  W = vim.lsp.protocol.DiagnosticSeverity.Warning,
+  E = vim.lsp.protocol.DiagnosticSeverity.Error,
+}
 
 return {
-    cmd = 'luacheck',
-    stdin = true,
-    args = {'--formatter', 'plain', '--codes', '--ranges', '-'},
-    ignore_exitcode = true,
-    parser = function(output, _)
-        local result = vim.fn.split(output, "\n")
-        local diagnostics = {}
-
-        for _, message in ipairs(result) do
-            local line, offs, offe, severity, code, desc =
-                string.match(message, pattern)
-
-            line = tonumber(line or 1) - 1
-            offs = tonumber(offs or 1) - 1
-            offe = tonumber(offe or 1)
-
-            table.insert(diagnostics, {
-                source = 'luacheck',
-                range = {
-                    ['start'] = {line = line, character = offs},
-                    ['end'] = {line = line, character = offe}
-                },
-                message = desc,
-                severity = assert(severities[severity],
-                                  'missing mapping for severity ' .. severity),
-                code = code
-            })
-        end
-
-        return diagnostics
-    end
+  cmd = 'luacheck',
+  stdin = true,
+  args = { '--formatter', 'plain', '--codes', '--ranges', '-' },
+  ignore_exitcode = true,
+  parser = require('lint.parser').from_pattern(pattern, groups, severities, { ['source'] = 'luacheck' }),
 }
-

--- a/lua/lint/linters/mypy.lua
+++ b/lua/lint/linters/mypy.lua
@@ -18,5 +18,5 @@ return {
     '--no-error-summary',
     '--no-pretty',
   },
-  parser = require('lint.parser').from_pattern(pattern, groups, severities),
+  parser = require('lint.parser').from_pattern(pattern, groups, severities, { ['source'] = 'mypy' }),
 }

--- a/lua/lint/linters/mypy.lua
+++ b/lua/lint/linters/mypy.lua
@@ -1,6 +1,6 @@
 -- path/to/file:line:col: severity: message
 local pattern = '([^:]+):(%d+):(%d+): (%a+): (.*)'
-local groups = { 'file', 'lineno', 'colno', 'severity', 'message' }
+local groups = { 'file', 'line', 'start_col', 'severity', 'message' }
 local severities = {
   error = vim.lsp.protocol.DiagnosticSeverity.Error,
   warning = vim.lsp.protocol.DiagnosticSeverity.Warning,

--- a/lua/lint/linters/mypy.lua
+++ b/lua/lint/linters/mypy.lua
@@ -1,6 +1,6 @@
 -- path/to/file:line:col: severity: message
 local pattern = '([^:]+):(%d+):(%d+): (%a+): (.*)'
-local groups = { 'file', 'lineno', 'colno', 'severity', 'msg' }
+local groups = { 'file', 'lineno', 'colno', 'severity', 'message' }
 local severities = {
   error = vim.lsp.protocol.DiagnosticSeverity.Error,
   warning = vim.lsp.protocol.DiagnosticSeverity.Warning,

--- a/lua/lint/linters/revive.lua
+++ b/lua/lint/linters/revive.lua
@@ -7,6 +7,6 @@ return {
   stdin = false,
   args = {},
   parser = require('lint.parser').from_pattern(pattern, groups, nil, {
-    source = 'revive',
+    ['source'] = 'revive',
   }),
 }

--- a/lua/lint/linters/revive.lua
+++ b/lua/lint/linters/revive.lua
@@ -1,15 +1,12 @@
 -- path/to/file:line:col: code message
-local pattern = "[^:]+:(%d+):(%d+): (.*) (.*)"
+local pattern = '[^:]+:(%d+):(%d+): (.*)'
+local groups = { 'lineno', 'colno', 'message' }
 
 return {
   cmd = 'revive',
   stdin = false,
   args = {},
-  parser = require('lint.parser').from_pattern(
-    pattern,
-    {
-      source = 'revive',
-      severity = vim.lsp.protocol.DiagnosticSeverity.Warning,
-    }
-  )
+  parser = require('lint.parser').from_pattern(pattern, groups, nil, {
+    source = 'revive',
+  }),
 }

--- a/lua/lint/linters/revive.lua
+++ b/lua/lint/linters/revive.lua
@@ -1,6 +1,6 @@
 -- path/to/file:line:col: code message
 local pattern = '[^:]+:(%d+):(%d+): (.*)'
-local groups = { 'lineno', 'colno', 'message' }
+local groups = { 'line', 'start_col', 'message' }
 
 return {
   cmd = 'revive',

--- a/lua/lint/linters/ruby.lua
+++ b/lua/lint/linters/ruby.lua
@@ -1,4 +1,23 @@
-local severities = vim.lsp.protocol.DiagnosticSeverity
+local pattern1 = '([^:]+):(%d+): warning: (.+)'
+local groups1 = { 'file', 'lineno', 'message' }
+
+local pattern2 = '([^:]+):(%d+): syntax error, (.+)'
+local groups2 = { 'file', 'lineno', 'message' }
+
+local parsers = {
+  require('lint.parser').from_pattern(
+    pattern1,
+    groups1,
+    nil,
+    { ['severity'] = vim.lsp.protocol.DiagnosticSeverity.Warning, ['source'] = 'ruby' }
+  ),
+  require('lint.parser').from_pattern(
+    pattern2,
+    groups2,
+    nil,
+    { ['severity'] = vim.lsp.protocol.DiagnosticSeverity.Error, ['source'] = 'ruby' }
+  ),
+}
 
 return {
   cmd = 'ruby',
@@ -7,42 +26,14 @@ return {
   ignore_exitcode = true,
   stream = 'stderr',
   parser = function(output)
-    local items = {}
-
-    for line in vim.gsplit(output, '\n') do
-      -- `ruby -c` produces two kinds of messages:
-      --
-      -- /tmp/test.rb:1: warning: possibly useless use of + in void context
-      -- /tmp/test.rb:2: syntax error, unexpected `end', expecting end-of-input
-      local pattern = '([^:]+):(%d+): warning: (.+)'
-      local severity = severities.Warning
-
-      if line:find(': syntax error,', 1, true) then
-        pattern = '([^:]+):(%d+): syntax error, (.+)'
-        severity = severities.Error
-      end
-
-      local file, lnum, message = line:match(pattern)
-
-      if file and line and message then
-        table.insert(items, {
-          source = 'ruby',
-          range = {
-            ['start'] = {
-              line = tonumber(lnum) - 1,
-              character = 0,
-            },
-            ['end'] = {
-              line = tonumber(lnum) - 1,
-              character = 0,
-            }
-          },
-          message = message,
-          severity = severity
-        })
+    local diagnostics = {}
+    for _, parser in ipairs(parsers) do
+      local result = parser(output)
+      for _, diagnostic in ipairs(result) do
+        table.insert(diagnostics, diagnostic)
       end
     end
 
-    return items
-  end
+    return diagnostics
+  end,
 }

--- a/lua/lint/linters/ruby.lua
+++ b/lua/lint/linters/ruby.lua
@@ -1,8 +1,8 @@
 local pattern1 = '([^:]+):(%d+): warning: (.+)'
-local groups1 = { 'file', 'lineno', 'message' }
+local groups1 = { 'file', 'line', 'message' }
 
 local pattern2 = '([^:]+):(%d+): syntax error, (.+)'
-local groups2 = { 'file', 'lineno', 'message' }
+local groups2 = { 'file', 'line', 'message' }
 
 local parsers = {
   require('lint.parser').from_pattern(

--- a/lua/lint/linters/tidy.lua
+++ b/lua/lint/linters/tidy.lua
@@ -1,5 +1,5 @@
 local pattern = 'line (%d+) column (%d+) %- (%a+): (.+)'
-local groups = { 'lineno', 'colno', 'severity', 'severity', 'message' }
+local groups = { 'lineno', 'colno', 'severity', 'message' }
 local severities = {
   Info = vim.lsp.protocol.DiagnosticSeverity.Information,
   Warning = vim.lsp.protocol.DiagnosticSeverity.Warning,

--- a/lua/lint/linters/tidy.lua
+++ b/lua/lint/linters/tidy.lua
@@ -1,5 +1,5 @@
 local pattern = 'line (%d+) column (%d+) %- (%a+): (.+)'
-local groups = { 'lineno', 'colno', 'severity', 'message' }
+local groups = { 'line', 'start_col', 'severity', 'message' }
 local severities = {
   Info = vim.lsp.protocol.DiagnosticSeverity.Information,
   Warning = vim.lsp.protocol.DiagnosticSeverity.Warning,

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -43,10 +43,6 @@ function M.from_pattern(pattern, groups, severity_map, defaults)
       return entries['code_desc']
     end,
 
-    data = function(_)
-      return nil -- Unsupported
-    end,
-
     message = function(entries)
       return entries['message']
     end,
@@ -61,20 +57,8 @@ function M.from_pattern(pattern, groups, severity_map, defaults)
       }
     end,
 
-    relatedInformation = function(_)
-      return nil -- Unsupported
-    end,
-
     severity = function(entries)
       return severity_map[entries['severity']] or defaults['severity'] or severity_map['error']
-    end,
-
-    source = function(_)
-      return nil -- Unsupported
-    end,
-
-    tags = function(_)
-      return nil -- Unsupported
     end,
   }
 

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -73,7 +73,7 @@ function M.from_pattern(pattern, groups, severity_map, defaults)
     end,
 
     severity = function(entries)
-      return severity_map[entries['severity']] or severity_map['error']
+      return severity_map[entries['severity']] or defaults['severity'] or severity_map['error']
     end,
 
     source = function(_)

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -30,7 +30,7 @@ end
 
 --- Parse a linter's output using a regex pattern
 -- @param pattern The regex pattern
--- @param groups The groups defined by the pattern: {"lineno", "message", ("colno" | "colbeg", "colend") [")code", "codeDesc", "severity", "colbeg", "colend"]}
+-- @param groups The groups defined by the pattern: {"lineno", "message", ("colno" | "colbeg", "colend"), ["code"], ["codeDesc"], ["file"], ["severity"]}
 -- @param severity_map An optional table mapping the severity values to their codes
 -- @param defaults An optional table of diagnostic default values
 function M.from_pattern(pattern, groups, severity_map, defaults)

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -30,7 +30,7 @@ end
 
 --- Parse a linter's output using a regex pattern
 -- @param pattern The regex pattern
--- @param groups The groups defined by the pattern: {"lineno", "message", ("colno" | "colbeg", "colend"), ["code"], ["codeDesc"], ["file"], ["severity"]}
+-- @param groups The groups defined by the pattern: {"line", "message", "start_col", ["end_col"], ["code"], ["code_desc"], ["file"], ["severity"]}
 -- @param severity_map An optional table mapping the severity values to their codes
 -- @param defaults An optional table of diagnostic default values
 function M.from_pattern(pattern, groups, severity_map, defaults)
@@ -40,7 +40,7 @@ function M.from_pattern(pattern, groups, severity_map, defaults)
     end,
 
     codeDescription = function(entries)
-      return entries['codeDesc']
+      return entries['code_desc']
     end,
 
     data = function(_)
@@ -52,19 +52,12 @@ function M.from_pattern(pattern, groups, severity_map, defaults)
     end,
 
     range = function(entries)
-      local lineno = tonumber(entries['lineno'])
-      if entries['colbeg'] ~= nil and entries['colend'] ~= nil then
-        local colbeg, colend = tonumber(entries['colbeg']), tonumber(entries['colend'])
-        return {
-          ['start'] = { line = lineno - 1, character = colbeg - 1 },
-          ['end'] = { line = lineno - 1, character = colend },
-        }
-      end
-
-      local colno = entries['colno'] ~= nil and tonumber(entries['colno']) or 1
+      local line = tonumber(entries['line'])
+      local start_col = tonumber(entries['start_col'])
+      local end_col = entries['end_col'] and tonumber(entries['end_col']) or start_col
       return {
-        ['start'] = { line = lineno - 1, character = colno - 1 },
-        ['end'] = { line = lineno - 1, character = colno },
+        ['start'] = { line = line - 1, character = start_col - 1 },
+        ['end'] = { line = line - 1, character = end_col },
       }
     end,
 


### PR DESCRIPTION
Hello,

I'd like to propose a change to the method named `from_pattern`, because it has a big impact I only recoded the function and will wait for your approval before going on.

The motivation is to support all the [Diagnostic](https://github.com/mfussenegger/nvim-lint#from_pattern) attributes and to make the parser flexible regarding what groups will be parsed using the regex.
This also allows adding new diagnostic fields in the future without worrying about refactoring.
Finally, I like the more concise and explicit definition of the parsers, for instance, I tested with cppcheck which could be defined as follows:
```
local pattern = [[([^:]*):(%d*):(%d*): %[([^%]\]*)%] ([^:]*): (.*)]]
local groups = {"file", "lineno", "colno", "code", "severity", "message" }
local severity_map = {
  ["error"] = vim.lsp.protocol.DiagnosticSeverity.Error,
  ["warning"] = vim.lsp.protocol.DiagnosticSeverity.Warning,
  ["performance"] = vim.lsp.protocol.DiagnosticSeverity.Warning,
  ["style"] = vim.lsp.protocol.DiagnosticSeverity.Information,
  ["information"] = vim.lsp.protocol.DiagnosticSeverity.Information,
}
local parser = from_pattern(pattern, groups, severity_map)

```