### PR TITLE
Add clj-kondo for Clojure(script)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Other dedicated linters that are built-in are:
 | [luacheck][19]      | `luacheck`     |
 | [chktex][20]        | `chktex`       |
 | [vint][21]          | `vint`         |
+| [clj-kondo][24]     | `clj-kondo`    |
 
 
 ## Custom Linters
@@ -251,3 +252,4 @@ export interface Diagnostic {
 [21]: https://github.com/Vimjas/vint
 [22]: https://github.com/danmar/cppcheck/
 [23]: https://clang.llvm.org/extra/clang-tidy/
+[24]: https://github.com/clj-kondo/clj-kondo

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -21,6 +21,7 @@ M.linters_by_ft = {
   rst = {'vale',},
   ruby = {'ruby',},
   inko = {'inko',},
+  clojure = {'clj-kondo',},
 }
 
 

--- a/lua/lint/linters/clj-kondo.lua
+++ b/lua/lint/linters/clj-kondo.lua
@@ -1,0 +1,38 @@
+local severities = {
+  error = vim.lsp.protocol.DiagnosticSeverity.Error,
+  warning = vim.lsp.protocol.DiagnosticSeverity.Warning,
+}
+
+return {
+  cmd = 'clj-kondo',
+  stdin = true,
+  stream = 'stdout',
+  ignore_exitcode = true,
+  args = {
+    '--config', '{:output {:format :json}}', '--parallel', '--lint', '-',
+  },
+  parser = function(output)
+    local decoded = vim.fn.json_decode(output) or {}
+    local findings = decoded.findings
+    local diagnostics = {}
+
+    for _, finding in pairs(findings or {}) do
+      table.insert(diagnostics, {
+        range = {
+          ['start'] = {
+            line = finding.row - 1,
+            character = finding.col,
+          },
+          ['end'] = {
+            line = finding.row - 1,
+            character = finding.col,
+          },
+        },
+        severity = assert(severities[finding.level], 'missing mapping for severity ' .. finding.level),
+        message = finding.message,
+      })
+    end
+
+    return diagnostics
+  end,
+}


### PR DESCRIPTION
- Adds [clj-kondo](https://github.com/clj-kondo/clj-kondo) as a linter for clojure and clojurescript files