### PR TITLE
Add StandardRB

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Other dedicated linters that are built-in are:
 | [Pylint][15]        | `pylint`       |
 | [Golangci-lint][16] | `golangcilint` |
 | Ruby                | `ruby`         |
+| [StandardRB][27]    | `standardrb`   |
 | [Inko][17]          | `inko`         |
 | [cppcheck][22]      | `cppcheck`     |
 | [clang-tidy][23]    | `clangtidy`    |
@@ -258,3 +259,4 @@ export interface Diagnostic {
 [24]: https://github.com/clj-kondo/clj-kondo
 [25]: https://github.com/eslint/eslint
 [26]: https://github.com/DavidAnson/markdownlint
+[27]: https://github.com/testdouble/standard

--- a/lua/lint/linters/standardrb.lua
+++ b/lua/lint/linters/standardrb.lua
@@ -1,0 +1,32 @@
+local sev = vim.lsp.protocol.DiagnosticSeverity
+
+return {
+  cmd = "standardrb",
+  args = {"--force-exclusion", "--stdin", "%:p", "--format", "json"},
+  stdin = true,
+  parser = function(output)
+    local diagnostics = {}
+    local decoded = vim.fn.json_decode(output)
+    local offences = decoded.files[1].offenses
+
+    for _, off in pairs(offences or {}) do
+      table.insert(diagnostics, {
+        range = {
+          ['start'] = {
+            line = off.location.start_line - 1,
+            character = off.location.start_column - 1
+          },
+          ['end'] = {
+            line = off.location.last_line - 1,
+            character = off.location.last_column
+          },
+        },
+        severity = (off.severity == "error" and sev.Error or sev.Warning ),
+        message = off.message,
+        code = off.cop_name,
+      })
+    end
+
+   return diagnostics
+ end,
+}


### PR DESCRIPTION
This adds the ruby linter for standardrb.

This ends up looking like this
<img width="603" alt="image" src="https://user-images.githubusercontent.com/1973/126398067-d37c454f-713a-483d-9eb0-9bcc6c8d5724.png">

I was hoping that by returning the code that it would show up somehow, but I don’t see how to get at it. I was wondering if I should prepend it like this instead?

<img width="874" alt="image" src="https://user-images.githubusercontent.com/1973/126399013-992bae58-bd21-4e9f-87d0-a51f2c5fe008.png">

It's useful to know the name you want to disable that check.