### PR TITLE
Improve clj-kondo setup

### DIFF
--- a/lua/lint/linters/clj-kondo.lua
+++ b/lua/lint/linters/clj-kondo.lua
@@ -3,13 +3,17 @@ local severities = {
   warning = vim.lsp.protocol.DiagnosticSeverity.Warning,
 }
 
+local function get_file_name(bufnr)
+  return vim.api.nvim_buf_get_name(bufnr)
+end
+
 return {
   cmd = 'clj-kondo',
   stdin = true,
   stream = 'stdout',
   ignore_exitcode = true,
   args = {
-    '--config', '{:output {:format :json}}', '--parallel', '--lint', '-',
+    '--config', '{:output {:format :json}}', '--filename', get_file_name, '--lint', '-',
   },
   parser = function(output)
     local decoded = vim.fn.json_decode(output) or {}

--- a/lua/lint/linters/clj-kondo.lua
+++ b/lua/lint/linters/clj-kondo.lua
@@ -3,8 +3,8 @@ local severities = {
   warning = vim.lsp.protocol.DiagnosticSeverity.Warning,
 }
 
-local function get_file_name(bufnr)
-  return vim.api.nvim_buf_get_name(bufnr)
+local function get_file_name()
+  return vim.api.nvim_buf_get_name(0)
 end
 
 return {


### PR DESCRIPTION
Based on feedback from the author @borkdude:
- Removed the --parallel option as it performs better on multiple files
  than one buffer which is the case here.
- Pass the file name from the buffer to help clj-kondo determine the
  type(clj, cljs, cljc, edn) better