### PR TITLE
fix: use values from the defaults table

### DIFF
--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -89,8 +89,10 @@ function M.from_pattern(pattern, groups, severity_map, defaults)
           local diagnostic = {}
 
           for key, handler in pairs(group_handler) do
-            diagnostic[key] = handler(entries) or defaults[key]
+            diagnostic[key] = handler(entries)
           end
+
+          diagnostic = vim.tbl_deep_extend("force", defaults, diagnostic)
           table.insert(diagnostics, diagnostic)
         end
       end


### PR DESCRIPTION
The defaults table was not used at all because the loop would iterate
over only those keys present in the `group_handler` table.

An example would be `flake8` where the defaults contain the `source` key
but it is ignored as that key is absent from the `group_handler` table.

Solution:
Merge the diagnostic table with the defaults table after constructing
the diagnostic table as per the linter output.