### PR TITLE
Remove `--project=` option for cppcheck

### DIFF
--- a/lua/lint/linters/cppcheck.lua
+++ b/lua/lint/linters/cppcheck.lua
@@ -14,7 +14,6 @@ return {
   args = {
     '--enable=warning,style,performance,information',
     '--language=c++',
-    '--project=build/compile_commands.json',
     '--inline-suppr',
     '--quiet',
     '--cppcheck-build-dir=build',


### PR DESCRIPTION
Closes https://github.com/mfussenegger/nvim-lint/issues/46
