### PR TITLE
flake8: ignore exit code

### DIFF
--- a/lua/lint/linters/flake8.lua
+++ b/lua/lint/linters/flake8.lua
@@ -9,6 +9,7 @@ return {
     '--format=%(path)s:%(row)d:%(col)d:%(code)s:%(text)s',
     '--no-show-source',
   },
+  ignore_exitcode = true,
   parser = require('lint.parser').from_pattern(pattern, groups, nil, {
     ['source'] = 'flake8',
   }),


### PR DESCRIPTION
flake8 returns an exit code of 1 when it finds errors, which should be
ignored.
