### PR TITLE
flake8: use Warning as default severity

### DIFF
--- a/lua/lint/linters/flake8.lua
+++ b/lua/lint/linters/flake8.lua
@@ -12,5 +12,6 @@ return {
   ignore_exitcode = true,
   parser = require('lint.parser').from_pattern(pattern, groups, nil, {
     ['source'] = 'flake8',
+    ['severity'] = vim.lsp.protocol.DiagnosticSeverity.Warning,
   }),
 }


### PR DESCRIPTION
Since the overwhelming majority (maybe all?) of the "errors" that flake8 emits are, in fact, style/lint warnings, it makes more sense to default to using Warning as the default severity rather than Error.
