### PR TITLE
Disable stdin for luacheck

### DIFF
--- a/lua/lint/linters/luacheck.lua
+++ b/lua/lint/linters/luacheck.lua
@@ -7,8 +7,8 @@ local severities = {
 
 return {
   cmd = 'luacheck',
-  stdin = true,
-  args = { '--formatter', 'plain', '--codes', '--ranges', '-' },
+  stdin = false,
+  args = { '--formatter', 'plain', '--codes', '--ranges'},
   ignore_exitcode = true,
   parser = require('lint.parser').from_pattern(pattern, groups, severities, { ['source'] = 'luacheck' }),
 }


### PR DESCRIPTION
There is some weird bug where luacheck will report EOF errors in the
middle of the file.

I managed to avoid the error if the `stdin:write` calls get throttled -
but that's not an acceptable fix within nvim-lint.

I'm not sure if this is some luv related bug, or if the problem is on
the luacheck side.

This disables the stdin support for now to get it working.
