### PR TITLE
Add fennel

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Other dedicated linters that are built-in are:
 | [codespell][18]              | `codespell`    |
 | [cppcheck][22]               | `cppcheck`     |
 | [eslint][25]                 | `eslint`       |
+| fennel                       | `fennel`       |
 | [Flake8][13]                 | `flake8`       |
 | [Golangci-lint][16]          | `golangcilint` |
 | [hadolint][28]               | `hadolint`     |

--- a/lua/lint/linters/fennel.lua
+++ b/lua/lint/linters/fennel.lua
@@ -1,0 +1,25 @@
+local efm = "%EParse error in %f:%l,%ECompile error in %f:%l,%C%*\\s%m,%-C%p^,%-G%.%#"
+
+local M
+
+local function globals()
+    return table.concat(M.globals, ",")
+end
+
+M = {
+    cmd = "fennel",
+    args = { "--globals", globals, "--compile" },
+    stdin = false,
+    ignore_exit_code = true,
+    stream = "stderr",
+    parser = require("lint.parser").from_errorformat(efm, {
+        source = "fennel",
+        severity = vim.lsp.protocol.DiagnosticSeverity.Error,
+    }),
+
+    -- Users can modify this list like this:
+    --  require("lint.linters.fennel").globals = { "foo", "bar" }
+    globals = {},
+}
+
+return M


### PR DESCRIPTION
The fennel linter includes a `globals` key that users can customize using

```lua
require("lint.linters.fennel").globals = { "foo" }
```
