### PR TITLE
Add compiler_stdout and use global errorformat/makeprg as fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,34 +60,35 @@ There is a generic linter called `compiler` that uses the `makeprg` and
 Other dedicated linters that are built-in are:
 
 
-| Tool                         | Linter name    |
-| -------------------          | -------------- |
-| Set via `makeprg`            | `compiler`     |
-| [ansible-lint][ansible-lint] | `ansible_lint` |
-| [chktex][20]                 | `chktex`       |
-| [clang-tidy][23]             | `clangtidy`    |
-| [clj-kondo][24]              | `clj-kondo`    |
-| [codespell][18]              | `codespell`    |
-| [cppcheck][22]               | `cppcheck`     |
-| [eslint][25]                 | `eslint`       |
-| [Flake8][13]                 | `flake8`       |
-| [Golangci-lint][16]          | `golangcilint` |
-| [hadolint][28]               | `hadolint`     |
-| [HTML Tidy][12]              | `tidy`         |
-| [Inko][17]                   | `inko`         |
-| [Languagetool][5]            | `languagetool` |
-| [luacheck][19]               | `luacheck`     |
-| nix                          | `nix`          |
-| [markdownlint][26]           | `markdownlint` |
-| [Mypy][11]                   | `mypy`         |
-| [Pylint][15]                 | `pylint`       |
-| [Revive][14]                 | `revive`       |
-| Ruby                         | `ruby`         |
-| [ShellCheck][10]             | `shellcheck`   |
-| [StandardRB][27]             | `standardrb`   |
-| [stylelint][29]              | `stylelint`    |
-| [Vale][8]                    | `vale`         |
-| [vint][21]                   | `vint`         |
+| Tool                         | Linter name       |
+| -------------------          | --------------    |
+| Set via `makeprg`            | `compiler`        |
+| Set via `makeprg`            | `compiler_stdout` |
+| [ansible-lint][ansible-lint] | `ansible_lint`    |
+| [chktex][20]                 | `chktex`          |
+| [clang-tidy][23]             | `clangtidy`       |
+| [clj-kondo][24]              | `clj-kondo`       |
+| [codespell][18]              | `codespell`       |
+| [cppcheck][22]               | `cppcheck`        |
+| [eslint][25]                 | `eslint`          |
+| [Flake8][13]                 | `flake8`          |
+| [Golangci-lint][16]          | `golangcilint`    |
+| [hadolint][28]               | `hadolint`        |
+| [HTML Tidy][12]              | `tidy`            |
+| [Inko][17]                   | `inko`            |
+| [Languagetool][5]            | `languagetool`    |
+| [luacheck][19]               | `luacheck`        |
+| nix                          | `nix`             |
+| [markdownlint][26]           | `markdownlint`    |
+| [Mypy][11]                   | `mypy`            |
+| [Pylint][15]                 | `pylint`          |
+| [Revive][14]                 | `revive`          |
+| Ruby                         | `ruby`            |
+| [ShellCheck][10]             | `shellcheck`      |
+| [StandardRB][27]             | `standardrb`      |
+| [stylelint][29]              | `stylelint`       |
+| [Vale][8]                    | `vale`            |
+| [vint][21]                   | `vint`            |
 
 
 ## Custom Linters

--- a/lua/lint/linters/compiler.lua
+++ b/lua/lint/linters/compiler.lua
@@ -2,8 +2,15 @@ local api = vim.api
 
 
 return function()
-  local errorformat = api.nvim_buf_get_option(0, 'errorformat')
-  local makeprg = api.nvim_buf_get_option(0, 'makeprg')
+  local ok, errorformat = pcall(api.nvim_buf_get_option, 0, 'errorformat')
+  if not ok then
+    errorformat = vim.o.errorformat
+  end
+  local makeprg
+  ok, makeprg = pcall(api.nvim_buf_get_option, 0, 'makeprg')
+  if not ok then
+    makeprg = vim.o.makeprg
+  end
   local bufname = api.nvim_buf_get_name(0)
   local args = {
     api.nvim_get_option('shellcmdflag'),

--- a/lua/lint/linters/compiler_stdout.lua
+++ b/lua/lint/linters/compiler_stdout.lua
@@ -1,0 +1,6 @@
+return function()
+  local compiler = require('lint.linters.compiler')
+  local linter = compiler()
+  linter.stream = 'stdout'
+  return linter
+end

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -10,7 +10,7 @@ function M.from_errorformat(efm, skeleton)
     local defaults = {
       severity = vim.lsp.protocol.DiagnosticSeverity.Error,
     }
-    for _, item in pairs(qflist.items) do
+    for _, item in pairs(qflist.items or {}) do
       if item.valid == 1 then
         local col = item.col > 0 and item.col - 1 or 0
         local position = { line = item.lnum - 1, character = col }


### PR DESCRIPTION
Should fix https://github.com/mfussenegger/nvim-lint/issues/73
