### PR TITLE
Support stdout/stderr output and global efm/makeprg in compiler linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,3 +20,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_JSCPD: false
+          VALIDATE_PYTHON_BLACK: false

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -6,3 +6,9 @@ read_globals = {
   "describe",
   "it"
 }
+files['tests'] = {
+  ignore = {
+    '121',        -- Setting a read-only global variable.
+    '122',        -- Setting a read-only field of a global variable.
+  }
+}

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ require('lint').linters.your_linter_name = {
   cmd = 'linter_cmd',
   stdin = true, -- or false if it doesn't support content input via stdin. In that case the filename is automatically added to the arguments.
   args = {}, -- list of arguments. Can contain functions with zero arguments that will be evaluated once the linter is used.
-  stream = nil, -- ('stdout' | 'stderr') configure the stream to which the linter outputs the linting result.
+  stream = nil, -- ('stdout' | 'stderr' | 'both') configure the stream to which the linter outputs the linting result.
   ignore_exitcode = false, -- set this to true if the linter exits with a code != 0 and that's considered normal.
   env = nil, -- custom environment table to use with the external process. Note that this replaces the *entire* environment, it is not additive.
   parser = your_parse_function

--- a/lua/lint/linters/compiler.lua
+++ b/lua/lint/linters/compiler.lua
@@ -14,7 +14,7 @@ return function()
     args = args,
     stdin = false,
     append_fname = false,
-    stream = 'stderr',
+    stream = 'both',
     ignore_exitcode = true,
     parser = require('lint.parser').from_errorformat(errorformat)
   }

--- a/lua/lint/linters/compiler.lua
+++ b/lua/lint/linters/compiler.lua
@@ -2,8 +2,15 @@ local api = vim.api
 
 
 return function()
-  local errorformat = api.nvim_buf_get_option(0, 'errorformat')
-  local makeprg = api.nvim_buf_get_option(0, 'makeprg')
+  local ok, errorformat = pcall(api.nvim_buf_get_option, 0, 'errorformat')
+  if not ok then
+    errorformat = vim.o.errorformat
+  end
+  local makeprg
+  ok, makeprg = pcall(api.nvim_buf_get_option, 0, 'makeprg')
+  if not ok then
+    makeprg = vim.o.makeprg
+  end
   local bufname = api.nvim_buf_get_name(0)
   local args = {
     api.nvim_get_option('shellcmdflag'),

--- a/tests/both.py
+++ b/tests/both.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write('10: foo\n')
+sys.stderr.write('20: bar\n')

--- a/tests/compiler_spec.lua
+++ b/tests/compiler_spec.lua
@@ -1,0 +1,36 @@
+describe('compiler', function()
+  it('reads errors from both stdout and stderr', function()
+    local a = vim.api
+    local bufnr = a.nvim_create_buf(true, true)
+    a.nvim_set_current_buf(bufnr)
+    a.nvim_buf_set_option(bufnr, 'errorformat', '%l: %m')
+    a.nvim_buf_set_option(bufnr, 'makeprg', '/usr/bin/python tests/both.py')
+
+    local result = nil
+    vim.lsp.handlers['textDocument/publishDiagnostics'] = function(_, _, diagnostics)
+      result = diagnostics
+    end
+    require('lint').try_lint('compiler')
+
+    vim.wait(5000, function() return result ~= nil end)
+    local expected = {
+      {
+        message = 'foo',
+        range = {
+          start = { line = 9, character = 0, },
+          ['end'] = { line = 9, character = 0 },
+        },
+        severity = 1,
+      },
+      {
+        message = 'bar',
+        range = {
+          start = { line = 19, character = 0, },
+          ['end'] = { line = 19, character = 0 },
+        },
+        severity = 1,
+      },
+    }
+    assert.are.same(expected, result.diagnostics)
+  end)
+end)


### PR DESCRIPTION
See commits

Replaces https://github.com/mfussenegger/nvim-lint/pull/77
Fixes https://github.com/mfussenegger/nvim-lint/issues/73
