### PR TITLE
Revert "Disable stdin for luacheck"

### DIFF
--- a/lua/lint/linters/luacheck.lua
+++ b/lua/lint/linters/luacheck.lua
@@ -7,8 +7,8 @@ local severities = {
 
 return {
   cmd = 'luacheck',
-  stdin = false,
-  args = { '--formatter', 'plain', '--codes', '--ranges'},
+  stdin = true,
+  args = { '--formatter', 'plain', '--codes', '--ranges', '-' },
   ignore_exitcode = true,
   parser = require('lint.parser').from_pattern(pattern, groups, severities, { ['source'] = 'luacheck' }),
 }


### PR DESCRIPTION
This reverts commit 84261b62e0d1b3182daf7ae7d4fcfa71148b37b0.

Root cause of the issue was fixed with 359aa4fe3414da6a7abb9154b5b62bd2508748e6
