### PR TITLE
Feature/add pycodestyle linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Other dedicated linters that are built-in are:
 | [stylelint][29]              | `stylelint`    |
 | [Vale][8]                    | `vale`         |
 | [vint][21]                   | `vint`         |
+| [pycodestyle][pcs-docs]      | `pycodestyle`  |
 
 
 ## Custom Linters
@@ -303,3 +304,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [null-ls]: https://github.com/jose-elias-alvarez/null-ls.nvim
 [plenary]: https://github.com/nvim-lua/plenary.nvim
 [ansible-lint]: https://docs.ansible.com/lint.html
+[pcs-docs]: https://pycodestyle.pycqa.org/en/latest/

--- a/lua/lint/linters/pycodestyle.lua
+++ b/lua/lint/linters/pycodestyle.lua
@@ -1,0 +1,17 @@
+-- path/to/file:line:col:code:message
+local pattern = '[^:]+:(%d+):(%d+):(%w+):(.+)'
+local groups = { 'line', 'start_col', 'code', 'message' }
+
+return {
+  cmd = 'pycodestyle',
+  stdin = true,
+  args = {
+    '--format=%(path)s:%(row)d:%(col)d:%(code)s:%(text)s',
+    '-',
+  },
+  ignore_exitcode = true,
+  parser = require('lint.parser').from_pattern(pattern, groups, nil, {
+    ['source'] = 'pycodestyle',
+    ['severity'] = vim.lsp.protocol.DiagnosticSeverity.Warning,
+  }),
+}

--- a/tests/pycodestyle_lint_spec.lua
+++ b/tests/pycodestyle_lint_spec.lua
@@ -1,0 +1,46 @@
+describe('linter.pycodestyle', function()
+  it('can parse the output', function()
+    local parser = require('lint.linters.pycodestyle').parser
+    local result = parser([[
+    test.py:26:1:E302:expected 2 blank lines, found 1
+    test.py:37:80:E501:line too long (88 > 79 characters)
+    test.py:69:48:W291:trailing whitespace
+    test.py:411:13:E128:continuation line under-indented for visual indent
+    ]])
+    assert.are.same(4, #result)
+    local expected = {
+      source = 'pycodestyle',
+      code = 'E302',
+      message = 'expected 2 blank lines, found 1',
+      range = {
+        ['start'] = {
+          character = 0,
+          line = 25
+        },
+        ['end'] = {
+          character = 1,
+          line = 25
+        },
+      },
+      severity = vim.lsp.protocol.DiagnosticSeverity.Warning,
+    }
+    assert.are.same(expected, result[1])
+    local expected = {
+      source = 'pycodestyle',
+      code = 'W291',
+      message = 'trailing whitespace',
+      range = {
+        ['start'] = {
+          character = 47,
+          line = 68
+        },
+        ['end'] = {
+          character = 48,
+          line = 68
+        },
+      },
+      severity = vim.lsp.protocol.DiagnosticSeverity.Warning,
+    }
+    assert.are.same(expected, result[3])
+  end)
+end)

--- a/tests/pycodestyle_lint_spec.lua
+++ b/tests/pycodestyle_lint_spec.lua
@@ -1,4 +1,10 @@
 describe('linter.pycodestyle', function()
+  it("doesn't error on empty output", function()
+    local parser = require('lint.linters.pycodestyle').parser
+    parser('')
+    parser('  ')
+  end)
+
   it('can parse the output', function()
     local parser = require('lint.linters.pycodestyle').parser
     local result = parser([[
@@ -8,7 +14,7 @@ describe('linter.pycodestyle', function()
     test.py:411:13:E128:continuation line under-indented for visual indent
     ]])
     assert.are.same(4, #result)
-    local expected = {
+    local expected_error = {
       source = 'pycodestyle',
       code = 'E302',
       message = 'expected 2 blank lines, found 1',
@@ -24,8 +30,8 @@ describe('linter.pycodestyle', function()
       },
       severity = vim.lsp.protocol.DiagnosticSeverity.Warning,
     }
-    assert.are.same(expected, result[1])
-    local expected = {
+    assert.are.same(expected_error, result[1])
+    local expected_warning = {
       source = 'pycodestyle',
       code = 'W291',
       message = 'trailing whitespace',
@@ -41,6 +47,6 @@ describe('linter.pycodestyle', function()
       },
       severity = vim.lsp.protocol.DiagnosticSeverity.Warning,
     }
-    assert.are.same(expected, result[3])
+    assert.are.same(expected_warning, result[3])
   end)
 end)

--- a/tests/pycodestyle_spec.lua
+++ b/tests/pycodestyle_spec.lua
@@ -1,7 +1,0 @@
-describe('linter.pycodestyle', function()
-  it("doesn't error on empty output", function()
-    local parser = require('lint.linters.pycodestyle').parser
-    parser('')
-    parser('  ')
-  end)
-end)

--- a/tests/pycodestyle_spec.lua
+++ b/tests/pycodestyle_spec.lua
@@ -1,0 +1,7 @@
+describe('linter.pycodestyle', function()
+  it("doesn't error on empty output", function()
+    local parser = require('lint.linters.pycodestyle').parser
+    parser('')
+    parser('  ')
+  end)
+end)


### PR DESCRIPTION
Thanks for this plugin, it totally fits my needs! I've added pycodestyle linter included some basic tests, I prefer pycodestyle for linting over flake8, mypy or pylint as these all have more overlap with the python LSP. It's very much based to the flake8 linter that was already available.