### PR TITLE
Add backwards compatibility to cppcheck 1.34

### DIFF
--- a/lua/lint/linters/cppcheck.lua
+++ b/lua/lint/linters/cppcheck.lua
@@ -1,4 +1,5 @@
-local pattern = [[([^:]*):(%d*):(%d*): %[([^%]\]*)%] ([^:]*): (.*)]]
+-- cppcheck <= 1.84 doesn't support {column} so the start_col group is ambiguous
+local pattern = [[([^:]*):(%d*):([^:]*): %[([^%]\]*)%] ([^:]*): (.*)]]
 local groups = { 'file', 'line', 'start_col', 'code', 'severity', 'message' }
 local severity_map = {
   ['error'] = vim.lsp.protocol.DiagnosticSeverity.Error,

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -49,7 +49,7 @@ function M.from_pattern(pattern, groups, severity_map, defaults)
 
     range = function(entries)
       local line = tonumber(entries['line'])
-      local start_col = tonumber(entries['start_col'])
+      local start_col = tonumber(entries['start_col']) or 1
       local end_col = entries['end_col'] and tonumber(entries['end_col']) or start_col
       return {
         ['start'] = { line = line - 1, character = start_col - 1 },

--- a/tests/cppcheck_spec.lua
+++ b/tests/cppcheck_spec.lua
@@ -1,16 +1,17 @@
 describe('linter.cppcheck', function()
   it('can parse the output', function()
     local parser = require('lint.linters.cppcheck').parser
+    local bufnr = vim.uri_to_bufnr('file:///foo.cpp')
     local result = parser([[
-./foo.cpp:46:7: [unusedVariable] style: Unused variable: fd
-./foo.cpp:366:3: [postfixOperator] performance: Prefer prefix ++/-- operators for non-primitive types.
-./foo.cpp:46:{column}: [unusedVariable] style: Unused variable: fd
-./foo.cpp:366:{column}: [postfixOperator] performance: Prefer prefix ++/-- operators for non-primitive types.
-]])
+/foo.cpp:46:7: [unusedVariable] style: Unused variable: fd
+/foo.cpp:366:3: [postfixOperator] performance: Prefer prefix ++/-- operators for non-primitive types.
+/foo.cpp:46:{column}: [unusedVariable] style: Unused variable: fd
+/foo.cpp:366:{column}: [postfixOperator] performance: Prefer prefix ++/-- operators for non-primitive types.
+]], bufnr)
 
   assert.are.same(4, #result)
 
-  local expected = {
+  local expected_1_88 = {
     source = 'cppcheck',
     code = 'unusedVariable',
     message = 'Unused variable: fd',
@@ -26,9 +27,9 @@ describe('linter.cppcheck', function()
     },
     severity = vim.lsp.protocol.DiagnosticSeverity.Information,
   }
-  assert.are.same(expected, result[1])
+  assert.are.same(expected_1_88, result[1])
 
-  local expected = {
+  local expected_1_34 = {
     source = 'cppcheck',
     code = 'unusedVariable',
     message = 'Unused variable: fd',
@@ -44,7 +45,7 @@ describe('linter.cppcheck', function()
     },
     severity = vim.lsp.protocol.DiagnosticSeverity.Information,
   }
-  assert.are.same(expected, result[3])
+  assert.are.same(expected_1_34, result[3])
 
   end)
 end)

--- a/tests/cppcheck_spec.lua
+++ b/tests/cppcheck_spec.lua
@@ -1,0 +1,50 @@
+describe('linter.cppcheck', function()
+  it('can parse the output', function()
+    local parser = require('lint.linters.cppcheck').parser
+    local result = parser([[
+./foo.cpp:46:7: [unusedVariable] style: Unused variable: fd
+./foo.cpp:366:3: [postfixOperator] performance: Prefer prefix ++/-- operators for non-primitive types.
+./foo.cpp:46:{column}: [unusedVariable] style: Unused variable: fd
+./foo.cpp:366:{column}: [postfixOperator] performance: Prefer prefix ++/-- operators for non-primitive types.
+]])
+
+  assert.are.same(4, #result)
+
+  local expected = {
+    source = 'cppcheck',
+    code = 'unusedVariable',
+    message = 'Unused variable: fd',
+    range = {
+      ['start'] = {
+        character = 6,
+        line = 45,
+      },
+      ['end'] = {
+        character = 7,
+        line = 45,
+      }
+    },
+    severity = vim.lsp.protocol.DiagnosticSeverity.Information,
+  }
+  assert.are.same(expected, result[1])
+
+  local expected = {
+    source = 'cppcheck',
+    code = 'unusedVariable',
+    message = 'Unused variable: fd',
+    range = {
+      ['start'] = {
+        character = 0,
+        line = 45,
+      },
+      ['end'] = {
+        character = 1,
+        line = 45,
+      }
+    },
+    severity = vim.lsp.protocol.DiagnosticSeverity.Information,
+  }
+  assert.are.same(expected, result[3])
+
+  end)
+end)


### PR DESCRIPTION
Allow parser to parse `{column}` or the actual column number. Default
column to 1.

Addresses #87