### PR TITLE
More effective eslint capture groups

### DIFF
--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -1,4 +1,4 @@
-local pattern = [[%s*(%d+):(%d+)%s+(%w+)%s+([%w%s]+)%s+(.*)]]
+local pattern = [[%s*(%d+):(%d+)%s+(%w+)%s+(.+)%s+(%S*)]]
 local groups = { 'line', 'start_col', 'severity', 'message', 'code' }
 local severity_map = {
   ['error'] = vim.lsp.protocol.DiagnosticSeverity.Error,

--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -10,5 +10,6 @@ return {
   args = {},
   stdin = false,
   stream = 'stdout',
+  ignore_exitcode = true,
   parser = require('lint.parser').from_pattern(pattern, groups, severity_map, { ['source'] = 'eslint' }),
 }

--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -1,4 +1,4 @@
-local pattern = [[%s*(%d+):(%d+)%s+(%w+)%s+(.+)%s+(%S*)]]
+local pattern = [[%s*(%d+):(%d+)%s+(%w+)%s+(.+)%s+(%S+)]]
 local groups = { 'line', 'start_col', 'severity', 'message', 'code' }
 local severity_map = {
   ['error'] = vim.lsp.protocol.DiagnosticSeverity.Error,


### PR DESCRIPTION
Punctuation in error messages is now captured properly, which prevents some error messages from getting cut off or left out completely.

Addresses #69 and #92.