### PR TITLE
'message' group no longer captures trailing spaces in eslint pattern

### DIFF
--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -1,4 +1,4 @@
-local pattern = [[%s*(%d+):(%d+)%s+(%w+)%s+(.+)%s+(%S+)]]
+local pattern = [[%s*(%d+):(%d+)%s+(%w+)%s+(.+%S)%s+(%S+)]]
 local groups = { 'line', 'start_col', 'severity', 'message', 'code' }
 local severity_map = {
   ['error'] = vim.lsp.protocol.DiagnosticSeverity.Error,


### PR DESCRIPTION
This is a follow up to #93, further refining the 'message' capture group in the eslint pattern. This prevents trailing spaces from getting captured in the diagnostics messages.