### PR TITLE
Improve eslint, Added eslint_d, Implemented cmd fallback

### DIFF
--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -155,6 +155,22 @@ function M.lint(linter, client_id)
     detached = true
   }
   assert(linter.cmd, 'Linter definition must have a `cmd` set: ' .. vim.inspect(linter))
+
+  local cmd_type = type(linter.cmd)
+  assert((cmd_type == 'table' or cmd_type == 'string'), 'Expected `cmd` to be either string or table')
+
+  if cmd_type == "table" then
+    for _, cmd in ipairs(linter.cmd) do
+      assert(type(cmd) == 'string', 'Expected elements of table `cmd` to be string')
+      if vim.fn.executable(cmd) == 1 then
+        linter.cmd = cmd
+        goto start_lint
+      end
+    end
+    error("Could not find installed linter on your system")
+  end
+  ::start_lint::
+
   handle, pid_or_err = uv.spawn(linter.cmd, opts, function(code)
     stdout:close()
     stderr:close()

--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -1,3 +1,9 @@
+local function get_root (...)
+  local root_dir = require'lspconfig/util'.root_pattern(...)
+  local cwd = vim.fn.getcwd()
+  return root_dir(cwd)
+end
+
 local pattern = [[%s*(%d+):(%d+)%s+(%w+)%s+(.+%S)%s+(%S+)]]
 local groups = { 'line', 'start_col', 'severity', 'message', 'code' }
 local severity_map = {
@@ -5,10 +11,12 @@ local severity_map = {
   ['warn'] = vim.lsp.protocol.DiagnosticSeverity.Warning,
 }
 
+local root_dir = get_root('package.json')
+
 return {
-  cmd = 'eslint',
-  args = {},
-  stdin = false,
+  cmd = {root_dir .. '/node_modules/eslint/bin/eslint.js', 'eslint'},
+  args = {'--stdin'},
+  stdin = true,
   stream = 'stdout',
   ignore_exitcode = true,
   parser = require('lint.parser').from_pattern(pattern, groups, severity_map, { ['source'] = 'eslint' }),

--- a/lua/lint/linters/eslint_d.lua
+++ b/lua/lint/linters/eslint_d.lua
@@ -1,0 +1,23 @@
+local function get_root (...)
+  local root_dir = require'lspconfig/util'.root_pattern(...)
+  local cwd = vim.fn.getcwd()
+  return root_dir(cwd)
+end
+
+local pattern = [[%s*(%d+):(%d+)%s+(%w+)%s+(.+%S)%s+(%S+)]]
+local groups = { 'line', 'start_col', 'severity', 'message', 'code' }
+local severity_map = {
+  ['error'] = vim.lsp.protocol.DiagnosticSeverity.Error,
+  ['warn'] = vim.lsp.protocol.DiagnosticSeverity.Warning,
+}
+
+local root_dir = get_root('package.json')
+
+return {
+  cmd = {root_dir .. '/node_modules/eslint_d/bin/eslint_d.js', 'eslint_d'},
+  args = {'--stdin'},
+  stdin = true,
+  stream = 'stdout',
+  ignore_exitcode = true,
+  parser = require('lint.parser').from_pattern(pattern, groups, severity_map, { ['source'] = 'eslint_d' }),
+}


### PR DESCRIPTION
- added [eslint_d](https://github.com/mantoni/eslint_d.js/)
- eslint now should look for local installation first then fallback to global
- now use stdin instead
- I also made a little modification to the core that allow `cmd` to accept table which take list of cmd as fallback (this doesn't break anything because you can still use string as normally)