### PR TITLE
Checkstyle

### DIFF
--- a/lua/lint/linters/checkstyle.lua
+++ b/lua/lint/linters/checkstyle.lua
@@ -1,0 +1,11 @@
+local format = '[%tRROR] %f:%l: %m, [%tRROR] %f:%l:%c: %m, [%tARN] %f:%l:%c: %m, [%tARN] %f:%l: %m'
+
+return {
+  cmd = 'checkstyle',
+  args = { '-p' },
+  ignore_exitcode = true,
+  parser = require('lint.parser').from_errorformat(format, {
+    source = 'checkstyle',
+    severity = vim.lsp.protocol.DiagnosticSeverity.Information
+  })
+}

--- a/lua/lint/linters/checkstyle.lua
+++ b/lua/lint/linters/checkstyle.lua
@@ -1,11 +1,22 @@
 local format = '[%tRROR] %f:%l: %m, [%tRROR] %f:%l:%c: %m, [%tARN] %f:%l:%c: %m, [%tARN] %f:%l: %m'
 
-return {
+local M
+
+local function config()
+  if M.config_file == nil then
+    error "Missing checkstyle config. e.g.: `require('lint.linters.checkstyle').config_file = '/path/to/checkstyle_config.xml'`"
+  end
+  return M.config_file
+end
+
+M = {
   cmd = 'checkstyle',
-  args = { '-p' },
+  args = {'-c', config},
   ignore_exitcode = true,
   parser = require('lint.parser').from_errorformat(format, {
     source = 'checkstyle',
-    severity = vim.lsp.protocol.DiagnosticSeverity.Information
-  })
+  }),
+  config_file = nil
 }
+
+return M

--- a/tests/checkstyle_spec.lua
+++ b/tests/checkstyle_spec.lua
@@ -1,0 +1,45 @@
+describe('linter.checkstyle', function()
+  it('can parse the output', function()
+    local parser = require('lint.linters.checkstyle').parser
+    local result = parser([[
+Starting audit...
+[WARN] src/main/java/com/foo/bar/ApiClient.java:75:1: 'member def modifier' has incorrect indentation level 0, expected level should be 2. [Indentation]
+[ERROR] src/main/java/com/foo/bar/ApiClient.java:187: Line is longer than 120 characters (found 143). [LineLength]
+Audit done.
+Checkstyle ends with 1 errors.
+]])
+    assert.are.same(2, #result)
+    local expected = {
+      source = 'checkstyle',
+      message = "Line is longer than 120 characters (found 143). [LineLength]",
+      range = {
+        ['start'] = {
+          character = 0,
+          line = 186,
+        },
+        ['end'] = {
+          character = 0,
+          line = 186,
+        }
+      },
+      severity = vim.lsp.protocol.DiagnosticSeverity.Information,
+    }
+    assert.are.same(expected, result[2])
+    local expected = {
+      source = 'checkstyle',
+      message = "'member def modifier' has incorrect indentation level 0, expected level should be 2. [Indentation]",
+      range = {
+        ['start'] = {
+          character = 0,
+          line = 74,
+        },
+        ['end'] = {
+          character = 0,
+          line = 74,
+        }
+      },
+      severity = vim.lsp.protocol.DiagnosticSeverity.Information,
+    }
+    assert.are.same(expected, result[1])
+  end)
+end)

--- a/tests/checkstyle_spec.lua
+++ b/tests/checkstyle_spec.lua
@@ -20,9 +20,8 @@ Checkstyle ends with 1 errors.
         ['end'] = {
           character = 0,
           line = 186,
-        }
+        },
       },
-      severity = vim.lsp.protocol.DiagnosticSeverity.Information,
     }
     assert.are.same(expected, result[2])
     local expected = {
@@ -36,9 +35,8 @@ Checkstyle ends with 1 errors.
         ['end'] = {
           character = 0,
           line = 74,
-        }
+        },
       },
-      severity = vim.lsp.protocol.DiagnosticSeverity.Information,
     }
     assert.are.same(expected, result[1])
   end)


### PR DESCRIPTION
feature: checkstyle support

my first ever lua let alone PR for a neovim plugin :grinning: Please comment liberally. Didn't see any examples on how to pass in a config file (which checkstyle needs) so I took something similar from fennel.

I'm not sure how to get the severity from `errorformat`? The `%t` should pull it in, but it doesn't and I'm not aware where that shortcoming is.