### PR TITLE
Add ignore_exitcode to pylint

### DIFF
--- a/lua/lint/linters/pylint.lua
+++ b/lua/lint/linters/pylint.lua
@@ -11,6 +11,7 @@ return {
   args = {
     '-f', 'json'
   },
+  ignore_exitcode = true,
   parser = function(output)
     local decoded = vim.fn.json_decode(output)
     local diagnostics = {}


### PR DESCRIPTION
Fix #99

Pylint will only return exit code 0 if there's no error messages, linter config for pylint should ignore the exit code to prevent the message show up again and again.
