### PR TITLE
Fixing displayed range

### DIFF
--- a/lua/lint/linters/vale.lua
+++ b/lua/lint/linters/vale.lua
@@ -36,7 +36,7 @@ return {
           },
           ['end'] = {
             line = item.Line - 1,
-            character = item.Span[2] - 1,
+            character = item.Span[2],
           },
         },
         message = item.Message,


### PR DESCRIPTION
Ranges highlighted with `LspDiagnosticsUnderlineError`, `LspDiagnosticsUnderlineWarning`, `LspDiagnosticsUnderlineInformation`, `LspDiagnosticsUnderlineHint` with Vala were shorter than should be.
