### PR TITLE
Run linters with detached = false

### DIFF
--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -152,7 +152,7 @@ function M.lint(linter, client_id)
     stdio = {stdin, stdout, stderr},
     env = env,
     cwd = vim.fn.getcwd(),
-    detached = true
+    detached = false
   }
   assert(linter.cmd, 'Linter definition must have a `cmd` set: ' .. vim.inspect(linter))
   handle, pid_or_err = uv.spawn(linter.cmd, opts, function(code)


### PR DESCRIPTION
On windows running linters with `detached = true` may cause shells to
pop up shortly.

In case this causes any issues on other systems or with some linters we
can either follow up and add a `linter.detached` setting or do some
system check and only prevent detaching on windows.
