### PR TITLE
clangtidy: Handle 'note' messages as hints

### DIFF
--- a/lua/lint/linters/clangtidy.lua
+++ b/lua/lint/linters/clangtidy.lua
@@ -1,9 +1,19 @@
 local pattern = [[([^:]*):(%d+):(%d+): (%w+): ([^[]+)]]
 local groups = { 'file', 'line', 'start_col', 'severity', 'message' }
 
+local DiagnosticSeverity = vim.lsp.protocol.DiagnosticSeverity
+
+local severity_map = {
+  ['error'] = DiagnosticSeverity.Error,
+  ['warning'] = DiagnosticSeverity.Warning,
+  ['information'] = DiagnosticSeverity.Information,
+  ['hint'] = DiagnosticSeverity.Hint,
+  ['note'] = DiagnosticSeverity.Hint,
+}
+
 return {
   cmd = 'clang-tidy',
   stdin = false,
   args = { '--quiet' },
-  parser = require('lint.parser').from_pattern(pattern, groups, nil, { ['source'] = 'clang-tidy' }),
+  parser = require('lint.parser').from_pattern(pattern, groups, severity_map, { ['source'] = 'clang-tidy' }),
 }


### PR DESCRIPTION
By default they were treated as errors

I was also considering updating `from_pattern` to merge the severity map with the default one so that you don't have to re-specify everything. For now I decided to not do this, but if this is something you'd consider, let me know and I can implement that as well.