### PR TITLE
Add Statix

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Other dedicated linters that are built-in are:
 | [Selene][31]                 | `selene`       |
 | [ShellCheck][10]             | `shellcheck`   |
 | [StandardRB][27]             | `standardrb`   |
+| [statix check][33]           | `statix`       |
 | [stylelint][29]              | `stylelint`    |
 | [Vale][8]                    | `vale`         |
 | [vint][21]                   | `vint`         |
@@ -306,6 +307,7 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [30]: https://github.com/KDE/clazy
 [31]: https://github.com/Kampfkarren/selene
 [32]: https://github.com/ndmitchell/hlint
+[33]: https://github.com/NerdyPepper/statix
 [null-ls]: https://github.com/jose-elias-alvarez/null-ls.nvim
 [plenary]: https://github.com/nvim-lua/plenary.nvim
 [ansible-lint]: https://docs.ansible.com/lint.html

--- a/lua/lint/linters/statix.lua
+++ b/lua/lint/linters/statix.lua
@@ -1,0 +1,9 @@
+return {
+  cmd = 'statix',
+  stdin = false,
+  args = {'check', '-o', 'errfmt', '--'},
+  stream = 'stderr',
+  parser = require('lint.parser').from_errorformat('%f>%l:%c:%t:%n:%m', {
+    source = 'statix'
+  })
+}


### PR DESCRIPTION
Add the statix linting and suggestion tool for the Nix programming
language to both the linter configs and the list of available linters.

It uses errorformat, so it was really easy to write, and last I saw it
worked properly and found some issues with my dotfiles' flake.nix
file, defined manually and by using this fork.

Let me know if I should add a test or something. I'm just not sure
what I'd test.