### PR TITLE
Add flawfinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Other dedicated linters that are built-in are:
 | [eslint][25]                 | `eslint`       |
 | fennel                       | `fennel`       |
 | [Flake8][13]                 | `flake8`       |
+| [flawfinder][35]             | `flawfinder`   |
 | [Golangci-lint][16]          | `golangcilint` |
 | [hadolint][28]               | `hadolint`     |
 | [hlint][32]                  | `hlint`     |
@@ -310,6 +311,7 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [32]: https://github.com/ndmitchell/hlint
 [33]: https://github.com/NerdyPepper/statix
 [34]: https://www.mathworks.com/help/matlab/ref/mlint.html
+[35]: https://github.com/david-a-wheeler/flawfinder
 [null-ls]: https://github.com/jose-elias-alvarez/null-ls.nvim
 [plenary]: https://github.com/nvim-lua/plenary.nvim
 [ansible-lint]: https://docs.ansible.com/lint.html

--- a/lua/lint/linters/flawfinder.lua
+++ b/lua/lint/linters/flawfinder.lua
@@ -1,0 +1,26 @@
+-- Look for patterns like the following:
+--
+-- vuln.c:6:3:  [5] (buffer) gets:Does not check for buffer overflows (CWE-120, CWE-20).  Use fgets() instead.
+
+local pattern = [[^(.*):(\d+):(\d+): *\[([0-5])\] (.*)$]]
+local groups = { 'file', 'line', 'start_col', 'severity', 'message' }
+
+local DiagnosticSeverity = vim.lsp.protocol.DiagnosticSeverity
+
+local severity_map = {
+  ['5'] = DiagnosticSeverity.Warning,
+  ['4'] = DiagnosticSeverity.Warning,
+  ['3'] = DiagnosticSeverity.Warning,
+  ['2'] = DiagnosticSeverity.Warning,
+  ['1'] = DiagnosticSeverity.Warning,
+}
+
+return {
+  cmd = 'flawfinder',
+  stdin = false,
+  args = {'-S', '-Q', '-D', '-C', '--'},
+  stream = 'stdout',
+  parser = require('lint.parser').from_pattern(pattern, groups, severity_map, {
+    ['source'] = 'flawfinder'
+  })
+}

--- a/lua/lint/linters/flawfinder.lua
+++ b/lua/lint/linters/flawfinder.lua
@@ -2,7 +2,7 @@
 --
 -- vuln.c:6:3:  [5] (buffer) gets:Does not check for buffer overflows (CWE-120, CWE-20).  Use fgets() instead.
 
-local pattern = [[^(.*):(\d+):(\d+): *\[([0-5])\] (.*)$]]
+local pattern = [[^(.*):(%d+):(%d+): *%[([0-5])%] (.*)$]]
 local groups = { 'file', 'line', 'start_col', 'severity', 'message' }
 
 local DiagnosticSeverity = vim.lsp.protocol.DiagnosticSeverity


### PR DESCRIPTION
Add support for flawfinder, a CWE enumeration tool for C/C++. 

Took me a couple of tries to figure out `from_pattern` since I didn't know Lua uses percent-signs for their regex escape character.