### PR TITLE
Update statix for v0.4.0

### DIFF
--- a/lua/lint/linters/statix.lua
+++ b/lua/lint/linters/statix.lua
@@ -1,8 +1,8 @@
 return {
   cmd = 'statix',
-  stdin = false,
-  args = {'check', '-o', 'errfmt', '--'},
-  stream = 'stderr',
+  stdin = true,
+  args = {'check', '-o', 'errfmt', '--stdin'},
+  stream = 'stdout',
   parser = require('lint.parser').from_errorformat('%f>%l:%c:%t:%n:%m', {
     source = 'statix'
   })


### PR DESCRIPTION
With the update to v0.4.0, statix introduced an "--stdin" flag, so this
linter can now support processing buffers, as well as a breaking change
of moving the lint output from stderr to stdout.