### PR TITLE
Add cspell Linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Other dedicated linters that are built-in are:
 | [clang-tidy][23]             | `clangtidy`    |
 | [clj-kondo][24]              | `clj-kondo`    |
 | [codespell][18]              | `codespell`    |
+| [cspell][36]                 | `cspell`       |
 | [cppcheck][22]               | `cppcheck`     |
 | [clazy][30]                  | `clazy`        |
 | [eslint][25]                 | `eslint`       |
@@ -312,6 +313,7 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [33]: https://github.com/NerdyPepper/statix
 [34]: https://www.mathworks.com/help/matlab/ref/mlint.html
 [35]: https://github.com/david-a-wheeler/flawfinder
+[36]: https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell
 [null-ls]: https://github.com/jose-elias-alvarez/null-ls.nvim
 [plenary]: https://github.com/nvim-lua/plenary.nvim
 [ansible-lint]: https://docs.ansible.com/lint.html

--- a/lua/lint/linters/cspell.lua
+++ b/lua/lint/linters/cspell.lua
@@ -1,0 +1,17 @@
+return {
+  cmd = 'cspell',
+  stdin = true,
+  args = {
+    'lint',
+    '--no-color',
+    '--no-progress',
+    '--no-summary',
+    '--',
+    'stdin'
+  },
+  stream = 'stdout',
+  parser = require('lint.parser').from_errorformat('/:%l:%c - %m', {
+    source = 'cspell',
+    severity = vim.lsp.protocol.DiagnosticSeverity.Information
+  })
+}

--- a/tests/cspell_spec.lua
+++ b/tests/cspell_spec.lua
@@ -1,0 +1,82 @@
+describe('linter.cspell', function()
+  it('can parse cspell output', function()
+    local parser = require('lint.linters.cspell').parser
+    local bufnr = vim.uri_to_bufnr('file:///foo.txt')
+    local result = parser([[
+/:259:8 - Unknown word (langserver)
+/:272:19 - Unknown word (noplugin)
+/:278:19 - Unknown word (noplugin)
+/:321:2 - Unknown word (checkstyle)
+]], bufnr)
+
+    assert.are.same(4, #result)
+
+    local expected_1 = {
+      source = 'cspell',
+      message = 'Unknown word (langserver)',
+      range = {
+        ['start'] = {
+          character = 7,
+          line = 258
+        },
+        ['end'] = {
+          character = 7,
+          line = 258
+        }
+      },
+      severity = vim.lsp.protocol.DiagnosticSeverity.Information,
+    }
+    assert.are.same(expected_1, result[1])
+
+    local expected_2 = {
+      source = 'cspell',
+      message = 'Unknown word (noplugin)',
+      range = {
+        ['start'] = {
+          character = 18,
+          line = 271
+        },
+        ['end'] = {
+          character = 18,
+          line = 271
+        }
+      },
+      severity = vim.lsp.protocol.DiagnosticSeverity.Information,
+    }
+    assert.are.same(expected_2, result[2])
+
+    local expected_3 = {
+      source = 'cspell',
+      message = 'Unknown word (noplugin)',
+      range = {
+        ['start'] = {
+          character = 18,
+          line = 277
+        },
+        ['end'] = {
+          character = 18,
+          line = 277
+        }
+      },
+      severity = vim.lsp.protocol.DiagnosticSeverity.Information,
+    }
+    assert.are.same(expected_3, result[3])
+
+    local expected_4 = {
+      source = 'cspell',
+      message = 'Unknown word (checkstyle)',
+      range = {
+        ['start'] = {
+          character = 1,
+          line = 320
+        },
+        ['end'] = {
+          character = 1,
+          line = 320
+        }
+      },
+      severity = vim.lsp.protocol.DiagnosticSeverity.Information,
+    }
+    assert.are.same(expected_4, result[4])
+  end)
+end)


### PR DESCRIPTION
Implement the `cspell` linter, one of the most popular extensions for VSCode.

Signed-off-by: David Houston <houstdav000@gmail.com>