### PR TITLE
Fix pylint to run successfully

### DIFF
--- a/lua/lint/linters/pylint.lua
+++ b/lua/lint/linters/pylint.lua
@@ -17,7 +17,7 @@ return {
     local buffer_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":~:.")
 
     for _, item in ipairs(vim.fn.json_decode(output) or {}) do
-      if not item.file or vim.fn.fnamemodify(item.file, ":~:.") == buffer_path then
+      if not item.path or vim.fn.fnamemodify(item.path, ":~:.") == buffer_path then
         local column = 0
         if item.column > 0 then
           column = item.column - 1

--- a/tests/pylint_spec.lua
+++ b/tests/pylint_spec.lua
@@ -1,0 +1,96 @@
+describe('linter.pylint', function()
+  it('can parse pylint output', function()
+    local parser = require('lint.linters.pylint').parser
+    local bufnr = vim.uri_to_bufnr('file:///file.py')
+    local result = parser([[
+[
+  {
+    "type": "warning",
+    "module": "two",
+    "obj": "",
+    "line": 4,
+    "column": 0,
+    "path": "two.py",
+    "symbol": "bad-indentation",
+    "message": "Bad indentation. Found 2 spaces, expected 4",
+    "message-id": "W0311"
+  },
+  {
+    "type": "convention",
+    "module": "two",
+    "obj": "",
+    "line": 1,
+    "column": 0,
+    "path": "two.py",
+    "symbol": "missing-module-docstring",
+    "message": "Missing module docstring",
+    "message-id": "C0114"
+  },
+  {
+    "type": "refactor",
+    "module": "two",
+    "obj": "",
+    "line": 3,
+    "column": 3,
+    "path": "two.py",
+    "symbol": "comparison-with-itself",
+    "message": "Redundant comparison - 1 == 1",
+    "message-id": "R0124"
+  }
+]
+]], bufnr)
+
+    assert.are.same(3, #result)
+
+    local expected_1 = {
+      message = 'Bad indentation. Found 2 spaces, expected 4',
+      range = {
+        ['start'] = {
+          character = 0,
+          line = 3
+        },
+        ['end'] = {
+          character = 0,
+          line = 3
+        }
+      },
+      severity = vim.lsp.protocol.DiagnosticSeverity.Warning,
+    }
+
+    assert.are.same(expected_1, result[1])
+
+    local expected_2 = {
+      message = 'Missing module docstring',
+      range = {
+        ['start'] = {
+          character = 0,
+          line = 0
+        },
+        ['end'] = {
+          character = 0,
+          line = 0
+        }
+      },
+      severity = vim.lsp.protocol.DiagnosticSeverity.Hint,
+    }
+
+    assert.are.same(expected_2, result[2])
+
+    local expected_3 = {
+      message = 'Redundant comparison - 1 == 1',
+      range = {
+        ['start'] = {
+          character = 2,
+          line = 2
+        },
+        ['end'] = {
+          character = 2,
+          line = 2
+        }
+      },
+      severity = vim.lsp.protocol.DiagnosticSeverity.Information,
+    }
+
+    assert.are.same(expected_3, result[3])
+  end)
+end)

--- a/tests/pylint_spec.lua
+++ b/tests/pylint_spec.lua
@@ -1,7 +1,7 @@
 describe('linter.pylint', function()
   it('can parse pylint output', function()
     local parser = require('lint.linters.pylint').parser
-    local bufnr = vim.uri_to_bufnr('file:///file.py')
+    local bufnr = vim.uri_to_bufnr('file:///two.py')
     local result = parser([[
 [
   {
@@ -10,7 +10,7 @@ describe('linter.pylint', function()
     "obj": "",
     "line": 4,
     "column": 0,
-    "path": "two.py",
+    "path": "/two.py",
     "symbol": "bad-indentation",
     "message": "Bad indentation. Found 2 spaces, expected 4",
     "message-id": "W0311"
@@ -21,7 +21,7 @@ describe('linter.pylint', function()
     "obj": "",
     "line": 1,
     "column": 0,
-    "path": "two.py",
+    "path": "/two.py",
     "symbol": "missing-module-docstring",
     "message": "Missing module docstring",
     "message-id": "C0114"
@@ -32,7 +32,7 @@ describe('linter.pylint', function()
     "obj": "",
     "line": 3,
     "column": 3,
-    "path": "two.py",
+    "path": "/two.py",
     "symbol": "comparison-with-itself",
     "message": "Redundant comparison - 1 == 1",
     "message-id": "R0124"


### PR DESCRIPTION
Pylint's parser function signature doesn't match the expected, so it's failing. Add logic for handling files from the `from_pattern` method to compensate.

Closes #115