### PR TITLE
Fix #125, Fix incorrect testing rtp, and add pydocstyle linter config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Other dedicated linters that are built-in are:
 | [Mypy][11]                   | `mypy`         |
 | nix                          | `nix`          |
 | [pycodestyle][pcs-docs]      | `pycodestyle`  |
+| [pydocstyle][pydocstyle]     | `pydocstyle`   |
 | [Pylint][15]                 | `pylint`       |
 | [Revive][14]                 | `revive`       |
 | [rflint][rflint]             | `rflint`       |
@@ -321,6 +322,7 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [plenary]: https://github.com/nvim-lua/plenary.nvim
 [ansible-lint]: https://docs.ansible.com/lint.html
 [pcs-docs]: https://pycodestyle.pycqa.org/en/latest/
+[pydocstyle]: https://www.pydocstyle.org/en/stable/
 [checkstyle]: https://checkstyle.sourceforge.io/
 [jshint]: https://jshint.com/
 [rflint]: https://github.com/boakley/robotframework-lint

--- a/lua/lint/linters/pydocstyle.lua
+++ b/lua/lint/linters/pydocstyle.lua
@@ -1,0 +1,9 @@
+return {
+  cmd = 'pydocstyle',
+  stdin = false,
+  ignore_exitcode = true,
+  parser = require('lint.parser').from_errorformat(
+    '%N%f:%l%.%#,%Z%s%#D%n: %m',
+    {source = 'pydocstyle'}
+  ),
+}

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -28,7 +28,7 @@ function M.from_errorformat(efm, skeleton)
             ['start'] = position,
             ['end'] = position,
           },
-          message = item.text,
+          message = item.text:match('^%s*(.-)%s*$'),
           severity = severity_by_qftype[item.type]
         }
         table.insert(result, vim.tbl_extend('keep', diagnostic, skeleton and skeleton or defaults))

--- a/tests/minimal.vim
+++ b/tests/minimal.vim
@@ -1,3 +1,2 @@
-set rtp+=.
-set rtp+=../plenary.nvim
+set rtp=.,../plenary.nvim,$VIMRUNTIME
 runtime! plugin/plenary.vim

--- a/tests/parser_spec.lua
+++ b/tests/parser_spec.lua
@@ -1,3 +1,56 @@
+describe('from_errorformat', function()
+  it('Parses single-line errorformat', function()
+    local efm = '%f:%l:%c:%t:%n:%m'
+    local skeleton = { source = 'test_case' }
+    local parser = require('lint.parser').from_errorformat(efm, skeleton)
+    local output = [[
+dir1/file1.txt:10:15:E:200:Big mistake
+dir2/file2.txt:20:25:W:300:Bigger mistake
+]]
+    local result = parser(output)
+    local expected = {
+      {
+        message = 'Big mistake',
+        range = {
+          ['start'] = {
+            line = 9,
+            character = 14,
+          },
+          ['end'] = {
+            line = 9,
+            character = 14,
+          }
+        },
+        severity = vim.lsp.protocol.DiagnosticSeverity.Error,
+        source = 'test_case',
+      },
+      {
+        message = 'Bigger mistake',
+        range = {
+          ['start'] = {
+            line = 19,
+            character = 24,
+          },
+          ['end'] = {
+            line = 19,
+            character = 24,
+          }
+        },
+        severity = vim.lsp.protocol.DiagnosticSeverity.Warning,
+        source = 'test_case',
+      },
+    }
+    assert.are.same(expected, result)
+  end)
+
+  it('Strips newlines and whitespace from error message', function()
+    -- NOTE: %m on subsequent line of multi-line emf will include a starting
+    -- newline character
+    local parser = require('lint.parser').from_errorformat('%W%l,%Z%m')
+    assert.equals('Big Mistake', parser('10\n \t Big Mistake \t \n')[1].message)
+  end)
+end)
+
 describe('from_pattern', function()
   it('Uses source from defaults', function()
     local pattern = '(.*):(%d+):(%d+) (.*)'

--- a/tests/pydocstyle_spec.lua
+++ b/tests/pydocstyle_spec.lua
@@ -1,0 +1,53 @@
+describe('linter.pydocstyle', function()
+  it("doesn't error on empty output", function()
+    local parser = require('lint.linters.pydocstyle').parser
+    parser('')
+    parser('  ')
+  end)
+
+  it('can parse the output', function()
+    local parser = require('lint.linters.pydocstyle').parser
+    local result = parser([[
+test.py:10 in public class `Foo`:
+        D200: One-line docstring should fit on one line with quotes (found 3)
+test.py:20 in public class `Bar`:
+        D208: Docstring is over-indented
+]]
+    )
+    assert.are.same(2, #result)
+
+    local expected_error = {
+      source = 'pydocstyle',
+      message = 'One-line docstring should fit on one line with quotes (found 3)',
+      range = {
+        ['start'] = {
+          line = 9,
+          character = 0,
+        },
+        ['end'] = {
+          line = 9,
+          character = 0,
+        },
+      },
+      severity = vim.lsp.protocol.DiagnosticSeverity.Hint,
+    }
+    assert.are.same(expected_error, result[1])
+
+    local expected_warning = {
+      source = 'pydocstyle',
+      message = 'Docstring is over-indented',
+      range = {
+        ['start'] = {
+          line = 19,
+          character = 0,
+        },
+        ['end'] = {
+          line = 19,
+          character = 0,
+        },
+      },
+      severity = vim.lsp.protocol.DiagnosticSeverity.Hint,
+    }
+    assert.are.same(expected_warning, result[2])
+  end)
+end)


### PR DESCRIPTION
__NOTES:__

- The pydocstyle config has the multi-line errorformat situation described in #125 and therefore it will benefit from the included fix for it. 
- The rtp fix is something I noticed after a long while having the test suite failing doing this PR before discovering the problem in the test setup.
- See extended commit messages for specific detail on each commit