### PR TITLE
golangci-lint: add FromLinter to diagnostic

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -43,6 +43,7 @@ return {
           },
         },
         severity = sv,
+        source = item.FromLinter,
         message = item.Text,
       })
     end


### PR DESCRIPTION
golangci-lint is a meta linter composing a number of other popular
linters according the config it reads. It is often helpful to know
exactly which linter produced a diagnostic. In fact, when run on the
command line, the tool prints the linter name by default.

This change updates the format of the diagnostic message to include the
linter. Note that while golangci-lint accepts
`--print-linter-name=false`, this setting appears to be ignored when
`-out-format json` is set.

-------------------------------------------

PR note: I am not sure if you accept contributions like this but I figured it was worth a shot. It is simple enough to override my parser locally, but I figured that in this case it may be worth updating the message to a sensible (in my opinion) default. No offense taken if you choose not to accept the change.

p.s: thanks for writing/maintaining this. I really appreciate the flexibility and minimalism. 