### PR TITLE
Fix `expected table, got nil` error if there are no linters for a filetype

### DIFF
--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -76,7 +76,7 @@ function M.try_lint(names)
   end
   if not names then
     local ft = vim.api.nvim_buf_get_option(0, 'filetype')
-    names = M.linters_by_ft[ft]
+    names = M.linters_by_ft[ft] or {}
   end
 
   local lookup_linter = function(name)


### PR DESCRIPTION
Fixes a regression introduced with https://github.com/mfussenegger/nvim-lint/commit/cc6b0f3ce3037a01fb371f502ba5f6301cb7f0a2
