### PR TITLE
severity matching for selene

### DIFF
--- a/lua/lint/linters/selene.lua
+++ b/lua/lint/linters/selene.lua
@@ -36,7 +36,7 @@ return {
                     },
                     source = "selene",
                     severity = assert(
-                        vim.diagnostic.severity[decoded.severity],
+                        vim.diagnostic.severity[string.upper(decoded.severity)],
                         "missing mapping for severity " .. decoded.severity
                     ),
                     lnum = start_line - 1,


### PR DESCRIPTION
selene uses severity levels like "Error", while nvim expects "ERROR"