### PR TITLE
Feature/add yamllint

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Other dedicated linters that are built-in are:
 | [Vale][8]                    | `vale`         |
 | [vint][21]                   | `vint`         |
 | [vulture][vulture]           | `vulture`      |
+| [yamllint][yamllint]         | `yamllint`     |
 
 
 ## Custom Linters
@@ -277,3 +278,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [rflint]: https://github.com/boakley/robotframework-lint
 [robocop]: https://github.com/MarketSquare/robotframework-robocop
 [vulture]: https://github.com/jendrikseipp/vulture
+[yamllint]: https://github.com/adrienverge/yamllint

--- a/lua/lint/linters/yamllint.lua
+++ b/lua/lint/linters/yamllint.lua
@@ -1,0 +1,17 @@
+-- path/to/file:line:col: [severity] message
+local pattern = '([^:]+):(%d+):(%d+): %[(.+)%] (.+)'
+local groups = { 'file', 'lnum', 'col', 'severity', 'message' }
+local severities = {
+  ['error'] = vim.diagnostic.severity.ERROR,
+  ['warning'] = vim.diagnostic.severity.WARN,
+}
+
+return {
+  cmd = 'yamllint',
+  stdin = false,
+  args = {'--format=parsable'},
+  ignore_exitcode = true,
+  parser = require('lint.parser').from_pattern(pattern, groups, severities, {
+    ['source'] = 'yamllint',
+  }),
+}

--- a/lua/lint/linters/yamllint.lua
+++ b/lua/lint/linters/yamllint.lua
@@ -1,6 +1,6 @@
--- path/to/file:line:col: [severity] message
-local pattern = '([^:]+):(%d+):(%d+): %[(.+)%] (.+)'
-local groups = { 'file', 'lnum', 'col', 'severity', 'message' }
+-- path/to/file:line:col: [severity] message (code)
+local pattern = '([^:]+):(%d+):(%d+): %[(.+)%] (.+) %((.+)%)'
+local groups = { 'file', 'lnum', 'col', 'severity', 'message', 'code' }
 local severities = {
   ['error'] = vim.diagnostic.severity.ERROR,
   ['warning'] = vim.diagnostic.severity.WARN,


### PR DESCRIPTION
New linter, this time for YAML (yamllint). Tested on my PC and everything work fine.
Output of `yamllint --format=parsable` is the following one:
```
cfg/euroc_cam1.yaml:13:24: [error] too many spaces after comma (commas)
cfg/euroc_cam1.yaml:17:2: [warning] missing starting space in comment (comments)
```