### PR TITLE
Flush stdin without extra newline

### DIFF
--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -168,7 +168,7 @@ function M.lint(linter)
     for _, line in ipairs(lines) do
       stdin:write(line .. '\n')
     end
-    stdin:write('\n', function()
+    stdin:write('', function()
       stdin:shutdown(function()
         stdin:close()
       end)


### PR DESCRIPTION
Fixes https://github.com/mfussenegger/nvim-lint/issues/144

Let's hope that's still good enough to keep
https://github.com/mfussenegger/nvim-lint/issues/131 closed.
