### PR TITLE
feat: add cpplint

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Other dedicated linters that are built-in are:
 | [clj-kondo][24]              | `clj-kondo`    |
 | [codespell][18]              | `codespell`    |
 | [cppcheck][22]               | `cppcheck`     |
+| [cpplint][cpplint]           | `cpplint`      |
 | [cspell][36]                 | `cspell`       |
 | [ESLint][25]                 | `eslint`       |
 | fennel                       | `fennel`       |
@@ -279,3 +280,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [robocop]: https://github.com/MarketSquare/robotframework-robocop
 [vulture]: https://github.com/jendrikseipp/vulture
 [yamllint]: https://github.com/adrienverge/yamllint
+[cpplint]: https://github.com/cpplint/cpplint

--- a/lua/lint/linters/cpplint.lua
+++ b/lua/lint/linters/cpplint.lua
@@ -1,0 +1,15 @@
+-- path/to/file:line:  message  [code] [code_id]
+local pattern = '([^:]+):(%d+):  (.+)  (.+)'
+local groups = { 'file', 'lnum', 'message', 'code'}
+
+return {
+  cmd = 'cpplint',
+  stdin = false,
+  args = {},
+  ignore_exitcode = true,
+  stream = 'stderr',
+  parser = require('lint.parser').from_pattern(pattern, groups, nil, {
+    ['source'] = 'cpplint',
+    ['severity'] = vim.diagnostic.severity.WARN,
+  }),
+}


### PR DESCRIPTION
New lint added. This static code checker ([repo here](https://github.com/cpplint/cpplint)) is checks that C++ code conforms the C++ google guidelines. Lightweight and fast one. Output example after executing the command:
```
src/file.cpp:78:  { should almost always be at the end of the previous line  [whitespace/braces] [4]
src/file.cpp:79:  Redundant blank line at the start of a code block should be deleted.  [whitespace/blank_line] [2]
```