### PR TITLE
feat: add proselint

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,4 +282,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [vulture]: https://github.com/jendrikseipp/vulture
 [yamllint]: https://github.com/adrienverge/yamllint
 [cpplint]: https://github.com/cpplint/cpplint
-[proselint]: https://github.com/amperser/proselint 
+[proselint]: https://github.com/amperser/proselint

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Other dedicated linters that are built-in are:
 | [mlint][34]                  | `mlint`        |
 | [Mypy][11]                   | `mypy`         |
 | nix                          | `nix`          |
+| [proselint][proselint]       | `proselint`    |
 | [pycodestyle][pcs-docs]      | `pycodestyle`  |
 | [pydocstyle][pydocstyle]     | `pydocstyle`   |
 | [Pylint][15]                 | `pylint`       |
@@ -281,3 +282,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [vulture]: https://github.com/jendrikseipp/vulture
 [yamllint]: https://github.com/adrienverge/yamllint
 [cpplint]: https://github.com/cpplint/cpplint
+[proselint]: https://github.com/amperser/proselint 

--- a/lua/lint/linters/proselint.lua
+++ b/lua/lint/linters/proselint.lua
@@ -1,0 +1,14 @@
+-- path/to/file:line:col: code.subcode.subsubcode message
+local pattern = '([^:]+):(%d+):(%d+): ([^ ]+) (.*)'
+local groups = { 'file', 'lnum', 'col', 'code', 'message' }
+
+return {
+  cmd = 'proselint',
+  stdin = false,
+  args = {},
+  ignore_exitcode = true,
+  parser = require('lint.parser').from_pattern(pattern, groups, nil, {
+    ['source'] = 'proselint',
+    ['severity'] = vim.diagnostic.severity.INFO,
+  }),
+}


### PR DESCRIPTION
Linter based on the grammar aspect! Expected cli output is the following one:
```
doc/dev/filename.rst:108:69: after_the_deadline.redundancy Redundancy. Use 'same' instead of 'same exact'.
doc/dev/filename.rst:147:33: typography.symbols.curly_quotes Use curly quotes “”, not straight quotes "".
doc/dev/filename.rst:151:33: typography.symbols.curly_quotes Use curly quotes “”, not straight quotes "".
```
I will be updating with a few different ones later :)