### PR TITLE
feat: add cmakelint

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Other dedicated linters that are built-in are:
 | [clang-tidy][23]             | `clangtidy`    |
 | [clazy][30]                  | `clazy`        |
 | [clj-kondo][24]              | `clj-kondo`    |
+| [cmakelint][cmakelint]       | `cmakelint`    |
 | [codespell][18]              | `codespell`    |
 | [cppcheck][22]               | `cppcheck`     |
 | [cpplint][cpplint]           | `cpplint`      |
@@ -283,3 +284,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [yamllint]: https://github.com/adrienverge/yamllint
 [cpplint]: https://github.com/cpplint/cpplint
 [proselint]: https://github.com/amperser/proselint
+[cmakelint]: https://github.com/cmake-lint/cmake-lint

--- a/lua/lint/linters/cmakelint.lua
+++ b/lua/lint/linters/cmakelint.lua
@@ -1,0 +1,14 @@
+-- path/to/file:line: message [code]
+local pattern = '([^:]+):(%d+): (.+) %[(.+)%]'
+local groups = { 'file', 'lnum', 'message', 'code' }
+
+return {
+  cmd = 'cmakelint',
+  stdin = false,
+  args = {'--quiet'},
+  ignore_exitcode = true,
+  parser = require('lint.parser').from_pattern(pattern, groups, nil, {
+    ['source'] = 'cmakelint',
+    ['severity'] = vim.diagnostic.severity.WARN,
+  }),
+}


### PR DESCRIPTION
[CMake linter](https://github.com/cmake-lint/cmake-lint). This one mainly checks format. I would like to add the one provided by the cmakelang ([cmake-lint](https://pypi.org/project/cmakelang/)). Although the have quite similar names, the first one (this one) checks for style and the other one seems to check for error/warnings in the code. CLI Output of the one from this PR:
```
conan.cmake:399: Extra spaces between 'foreach' and its () [whitespace/extra]
conan.cmake:400: Lines should be <= 80 characters long [linelength]
```