### PR TITLE
feat: add rstlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Other dedicated linters that are built-in are:
 | [rflint][rflint]             | `rflint`       |
 | [robocop][robocop]           | `robocop`      |
 | [rstcheck][rstcheck]         | `rstcheck`     |
+| [rstlint][rstlint]           | `rstlint`      |
 | Ruby                         | `ruby`         |
 | [Selene][31]                 | `selene`       |
 | [ShellCheck][10]             | `shellcheck`   |
@@ -287,3 +288,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [proselint]: https://github.com/amperser/proselint
 [cmakelint]: https://github.com/cmake-lint/cmake-lint
 [rstcheck]: https://github.com/myint/rstcheck
+[rstlint]: https://github.com/twolfson/restructuredtext-lint

--- a/lua/lint/linters/rstlint.lua
+++ b/lua/lint/linters/rstlint.lua
@@ -1,0 +1,19 @@
+-- severity path/to/file:line message
+local pattern = '(.*) (.*):(%d+) (.*)'
+local groups = { 'severity', 'file', 'lnum', 'message' }
+local severities = {
+  INFO = vim.diagnostic.severity.INFO,
+  WARNING = vim.diagnostic.severity.WARN,
+  ERROR = vim.diagnostic.severity.ERROR,
+  SEVERE = vim.diagnostic.severity.SEVERE,
+}
+
+return {
+  cmd = 'restructuredtext-lint',
+  stdin = false,
+  args = {},
+  ignore_exitcode = true,
+  parser = require('lint.parser').from_pattern(pattern, groups, severities, {
+    ['source'] = 'rstlint',
+  }),
+}


### PR DESCRIPTION
New linter: [restructuredtext-lint](https://github.com/twolfson/restructuredtext-lint)
It can be launched eitther with `rst-lint` or `restructuredtext-lint`. If the naming leads to confusion I can change also them. Example output:
```
ERROR doc/dev/example.rst:94 Unknown interpreted text role "ref".
```