### PR TITLE
Lookup linters for individual filetype on compound filetype

### DIFF
--- a/tests/lint_spec.lua
+++ b/tests/lint_spec.lua
@@ -1,0 +1,28 @@
+describe('lint', function()
+  local a = vim.api
+  local bufnr = a.nvim_create_buf(true, true)
+  a.nvim_buf_set_option(bufnr, 'filetype', 'ansible.yaml')
+  local lint = require('lint')
+
+  it('resolves all linters for compound filetypes', function()
+    lint.linters_by_ft = {
+      ansible = {'ansible-lint'},
+      yaml = {'yamllint'},
+    }
+    local names = lint._resolve_linter_by_ft('ansible.yaml')
+    local expected = {'ansible-lint', 'yamllint'}
+    table.sort(names, function(x, y) return x < y end)
+    assert.are.same(expected, names)
+  end)
+  it('deduplicates linters for compound filetypes', function()
+    lint.linters_by_ft = {
+      ansible = {'ansible-lint','yamllint'},
+      yaml = {'yamllint'},
+    }
+    local names = lint._resolve_linter_by_ft('ansible.yaml')
+    local expected = {'ansible-lint', 'yamllint'}
+    table.sort(names, function(x, y) return x < y end)
+    assert.are.same(expected, names)
+  end)
+end)
+


### PR DESCRIPTION
Add a fallback in case there is no entry for the full compound filetype
definition.

A filetype like `ansible.yaml` will first look for an `ansible.yaml`
entry and if it doesn't exist it will lookup both `ansible` and `yaml`
and merge the found linter names.

Closes https://github.com/mfussenegger/nvim-lint/issues/141
