### PR TITLE
fix: improve vulture scope

### DIFF
--- a/lua/lint/linters/vulture.lua
+++ b/lua/lint/linters/vulture.lua
@@ -1,12 +1,22 @@
 -- path/to/file:line: message
-local pattern = '([^:]+):(%d+):(.*)'
+local pattern = '([^:]+):(%d+): (.*)'
 local groups = { 'file', 'lnum', 'message' }
 
 return {
   cmd = 'vulture',
   stdin = false,
-  args = {},
+  args = {"--exclude='/**/docs/*.py,/**/build/*.py'", function()
+    local output = vim.fn.system("git rev-parse --show-toplevel"):sub(1, -2)
+    if output:match("^([%w]+)") == "fatal" then
+        -- Return the current dir
+        return vim.fn.getcwd()
+    else
+        -- Return the path to git root directory
+        return output
+    end
+  end},
   ignore_exitcode = true,
+  append_fname = false,
   parser = require('lint.parser').from_pattern(pattern, groups, nil, {
     ['source'] = 'vulture',
     ['severity'] = vim.diagnostic.severity.WARN,

--- a/lua/lint/linters/vulture.lua
+++ b/lua/lint/linters/vulture.lua
@@ -6,13 +6,11 @@ return {
   cmd = 'vulture',
   stdin = false,
   args = {"--exclude='/**/docs/*.py,/**/build/*.py'", function()
-    local output = vim.fn.system("git rev-parse --show-toplevel"):sub(1, -2)
-    if output:match("^([%w]+)") == "fatal" then
-        -- Return the current dir
+    local git_root_or_err = vim.fn.system("git rev-parse --show-toplevel"):sub(1, -2)
+    if vim.startswith(git_root_or_err, 'fatal') then
         return vim.fn.getcwd()
     else
-        -- Return the path to git root directory
-        return output
+        return git_root_or_err
     end
   end},
   ignore_exitcode = true,


### PR DESCRIPTION
The idea of this PR is to improve the scope of Vulture (dead code and unused variables analyzer). By default, the filename is passed as argument, which prevents the linter to analyze the full context of an entire repository. This leads to lots of false positives. The current implementation uses as input argument the git root directory if exists or the current dir otherwise. Tested both of them and works fine.

Fixes #153