### PR TITLE
Fix "Expected Lua number" test failures

### DIFF
--- a/tests/mlint_spec.lua
+++ b/tests/mlint_spec.lua
@@ -7,7 +7,7 @@ L 1 (C 7-9): CLALL: ML0: Using 'clear' with the 'all' option usually decreases c
 L 7 (C 18): ACABE: ML5: The McCabe cyclomatic complexity of the anonymous function on line 7 is 1.
 L 10 (C 48-51): SYNER: ML3: Parse error at recs: usage might be invalid MATLAB syntax.
 L 13 (C 1-3): RESWD: ML3: Invalid use of a reserved word.
-]])
+]], vim.api.nvim_get_current_buf())
   assert.are.same(5, #result)
 
   local expected = {

--- a/tests/pycodestyle_lint_spec.lua
+++ b/tests/pycodestyle_lint_spec.lua
@@ -1,8 +1,8 @@
 describe('linter.pycodestyle', function()
   it("doesn't error on empty output", function()
     local parser = require('lint.linters.pycodestyle').parser
-    parser('')
-    parser('  ')
+    parser('', vim.api.nvim_get_current_buf())
+    parser('  ', vim.api.nvim_get_current_buf())
   end)
 
   it('can parse the output', function()
@@ -12,7 +12,7 @@ describe('linter.pycodestyle', function()
     test.py:37:80:E501:line too long (88 > 79 characters)
     test.py:69:48:W291:trailing whitespace
     test.py:411:13:E128:continuation line under-indented for visual indent
-    ]])
+    ]], vim.api.nvim_get_current_buf())
     assert.are.same(4, #result)
     local expected_error = {
       source = 'pycodestyle',


### PR DESCRIPTION
Tests started to fail after https://github.com/neovim/neovim/pull/16745
because the tests didn't provide the buffer number to the parse
function.
