### PR TITLE
feat: add pytest-cov

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Other dedicated linters that are built-in are:
 | [pycodestyle][pcs-docs]      | `pycodestyle`  |
 | [pydocstyle][pydocstyle]     | `pydocstyle`   |
 | [Pylint][15]                 | `pylint`       |
+| [pytestcov][pytestcov]       | `pytestcov`    |
 | [Revive][14]                 | `revive`       |
 | [rflint][rflint]             | `rflint`       |
 | [robocop][robocop]           | `robocop`      |
@@ -289,3 +290,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [cmakelint]: https://github.com/cmake-lint/cmake-lint
 [rstcheck]: https://github.com/myint/rstcheck
 [rstlint]: https://github.com/twolfson/restructuredtext-lint
+[pytestcov]: https://github.com/pytest-dev/pytest-cov

--- a/lua/lint/linters/pytestcov.lua
+++ b/lua/lint/linters/pytestcov.lua
@@ -75,10 +75,10 @@ return {
 
     if tonumber(percentage_cover) == 0 then
       table.insert(diagnostics, {
-         lnum = 0,
-         col = 0,
-         severity = assert(vim.diagnostic.severity.INFO, 'missing mapping for severity info'),
-         message = messages.file_not_covered,
+        lnum = 0,
+        col = 0,
+        severity = assert(vim.diagnostic.severity.INFO, 'missing mapping for severity info'),
+        message = messages.file_not_covered,
       })
     else
       for non_covered_lines in non_covered_blocks:gmatch("([^,]+),?") do

--- a/lua/lint/linters/pytestcov.lua
+++ b/lua/lint/linters/pytestcov.lua
@@ -23,7 +23,14 @@ local source_pytestcov = "pytest-cov"
 return {
   cmd = 'pytest',
   stdin = false,
-  args = {"--cov-reset", "--cov-report=term-missing", "--cov=."},
+  args = {"--cov-reset", "--cov-report=term-missing", "--cov=.", function ()
+    local git_root_dir = vim.fn.system("git rev-parse --show-toplevel"):sub(1, -2)
+    if vim.startswith(git_root_dir, 'fatal') then
+      return ''
+    else
+      return git_root_dir
+    end
+  end},
   append_fname = false,
   ignore_exitcode = true,
   parser = function(output, bufnr)

--- a/lua/lint/linters/pytestcov.lua
+++ b/lua/lint/linters/pytestcov.lua
@@ -1,0 +1,106 @@
+local messages = {
+  file_not_covered = 'No test coverage was found for this file',
+  multiple_lines_not_covered = 'No test coverage found for these lines',
+  line_not_covered = 'No test coverage found for this line',
+  testing_error = 'No test coverage analysis could be performed due to errors'
+}
+
+local severities = {
+  error = vim.diagnostic.severity.ERROR,
+  info = vim.diagnostic.severity.INFO,
+}
+
+local ignored_files = {
+  "setup.py",
+  "docs/conf.py",
+  "test_.*.py",
+  "__init__.py",
+}
+
+return {
+  cmd = 'pytest',
+  stdin = false,
+  args = {"--cov-reset", "--cov-report=term-missing", "--cov=."},
+  append_fname = false,
+  ignore_exitcode = true,
+  parser = function(output, bufnr)
+    local diagnostics = {}
+    local buffer_report
+    local pattern_data_from_report = "(%d+)%%   (.*)"
+    local buffer_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":~:.")
+
+    for _, ignored_file in ipairs(ignored_files) do
+      if string.find(buffer_path, ignored_file) then
+          return {}
+      end
+    end
+
+    for line in string.gmatch(output, "[^\n]+") do
+      local file_path_relative = string.match(line, "(.*.py) ");
+      if file_path_relative ~= nil then
+        if string.find(buffer_path, file_path_relative) then
+          buffer_report = line
+          break
+        end;
+      end;
+    end;
+
+    if string.find(output, "Interrupted: ") and buffer_report == nil then
+      table.insert(diagnostics, {
+            lnum = 0,
+            col = 0,
+            severity = assert(severities.error, 'missing mapping for severity error'),
+            message = messages.testing_error,
+
+      })
+      return diagnostics
+    end
+
+
+    if buffer_report == nil then
+      table.insert(diagnostics, {
+            lnum = 0,
+            col = 0,
+            severity = assert(severities.info, 'missing mapping for severity info'),
+            message = messages.file_not_covered,
+      })
+      return diagnostics
+    end
+
+    if string.find(buffer_report, "100%%") then
+      return diagnostics
+    end
+
+    local percentage_cover, non_covered_blocks = string.match(buffer_report, pattern_data_from_report)
+
+    if tonumber(percentage_cover) == 0 then
+      table.insert(diagnostics, {
+         lnum = 0,
+         col = 0,
+         severity = assert(vim.diagnostic.severity.INFO, 'missing mapping for severity info'),
+         message = messages.file_not_covered,
+      })
+    else
+      for non_covered_lines in non_covered_blocks:gmatch("([^,]+),?") do
+          if string.find(non_covered_lines, "-") then
+              table.insert(diagnostics, {
+                lnum = tonumber(string.match(non_covered_lines,"(%d+)")) - 1,
+                col = 0,
+                end_lnum = tonumber(string.match(non_covered_lines,"-(%d+)")),
+                severity = assert(severities.info, 'missing mapping for severity info'),
+                message = messages.multiple_lines_not_covered
+              })
+          else
+              table.insert(diagnostics, {
+                lnum = tonumber(string.match(non_covered_lines,"(%d+).*")) - 1,
+                col = 0,
+                end_lnum = tonumber(string.match(non_covered_lines,"(%d+).*")),
+                severity = assert(vim.diagnostic.severity.INFO, 'missing mapping for severity info'),
+                message = messages.line_not_covered
+              })
+          end
+      end
+    end
+    return diagnostics
+  end,
+}

--- a/tests/pytestcov_spec.lua
+++ b/tests/pytestcov_spec.lua
@@ -1,0 +1,92 @@
+local output_str = [[
+---------- coverage: platform linux, python 3.8.10-final-0 -----------
+Name                            Stmts   Miss  Cover   Missing
+--------------------------------------------------------------------------
+one.py                             0      0     0%   3-104
+two.py                             52     9    83%   99-103, 111-114, 124
+three.py                           0      0   100%
+]]
+
+local errors_launching_tests = [[
+---------- coverage: platform linux, python 3.8.10-final-0 -----------
+Name                            Stmts   Miss  Cover   Missing
+--------------------------------------------------------------------------
+one.py                             0      0     0%   3-104
+two.py                             52     9    83%   99-103, 111-114, 124
+three.py                           0      0   100%
+
+============================================================================================= short test summary info =============================================================================================
+ERROR  - ModuleNotFoundError: No module named 'hypothesis'
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+]]
+
+describe('linter.pytestcov', function()
+  it('can parse pytestcov output', function()
+    local parser = require('lint.linters.pytestcov').parser
+    local bufnr_1 = vim.uri_to_bufnr('file:///home/repo/one.py')
+    local result_1 = parser(output_str, bufnr_1)
+    local expected_1 = {{
+      lnum = 0,
+      col = 0,
+      severity = vim.diagnostic.severity.INFO,
+      message = 'No test coverage was found for this file',
+    }}
+
+    assert.are.same(expected_1, result_1)
+
+    local bufnr_2 = vim.uri_to_bufnr('file:///home/repo/two.py')
+    local result_2 = parser(output_str, bufnr_2)
+    local expected_2 = {
+    {
+      lnum = 98,
+      col = 0,
+      end_lnum = 103,
+      severity = vim.diagnostic.severity.INFO,
+      message = 'No test coverage found for these lines',
+    },
+    {
+      lnum = 110,
+      col = 0,
+      end_lnum = 114,
+      severity = vim.diagnostic.severity.INFO,
+      message = 'No test coverage found for these lines',
+    },
+    {
+      lnum = 123,
+      col = 0,
+      end_lnum = 124,
+      severity = vim.diagnostic.severity.INFO,
+      message = 'No test coverage found for this line',
+    }}
+
+    assert.are.same(expected_2, result_2)
+
+    local bufnr_3 = vim.uri_to_bufnr('file:///home/repo/three.py')
+    local result_3 = parser(output_str, bufnr_3)
+    local expected_3 = {}
+
+    assert.are.same(expected_3, result_3)
+
+    local bufnr_4 = vim.uri_to_bufnr('file:///home/repo/four.py')
+    local result_4 = parser(output_str, bufnr_4)
+    local expected_4 = {{
+      lnum = 0,
+      col = 0,
+      severity = vim.diagnostic.severity.INFO,
+      message = 'No test coverage was found for this file',
+    }}
+
+    assert.are.same(expected_4, result_4)
+
+    local bufnr_5 = vim.uri_to_bufnr('file:///home/repo/four.py')
+    local result_5 = parser(errors_launching_tests, bufnr_5)
+    local expected_5 = {{
+      lnum = 0,
+      col = 0,
+      severity = vim.diagnostic.severity.ERROR,
+      message = 'No test coverage analysis could be performed due to errors',
+    }}
+
+    assert.are.same(expected_5, result_5)
+  end)
+end)

--- a/tests/pytestcov_spec.lua
+++ b/tests/pytestcov_spec.lua
@@ -26,6 +26,7 @@ describe('linter.pytestcov', function()
     local bufnr_1 = vim.uri_to_bufnr('file:///home/repo/one.py')
     local result_1 = parser(output_str, bufnr_1)
     local expected_1 = {{
+      source = 'pytest-cov',
       lnum = 0,
       col = 0,
       severity = vim.diagnostic.severity.INFO,
@@ -38,20 +39,23 @@ describe('linter.pytestcov', function()
     local result_2 = parser(output_str, bufnr_2)
     local expected_2 = {
     {
+      source = 'pytest-cov',
       lnum = 98,
       col = 0,
       end_lnum = 103,
       severity = vim.diagnostic.severity.INFO,
-      message = 'No test coverage found for these lines',
+      message = 'No test coverage found for these lines (until line 103)',
     },
     {
+      source = 'pytest-cov',
       lnum = 110,
       col = 0,
       end_lnum = 114,
       severity = vim.diagnostic.severity.INFO,
-      message = 'No test coverage found for these lines',
+      message = 'No test coverage found for these lines (until line 114)',
     },
     {
+      source = 'pytest-cov',
       lnum = 123,
       col = 0,
       end_lnum = 124,
@@ -70,6 +74,7 @@ describe('linter.pytestcov', function()
     local bufnr_4 = vim.uri_to_bufnr('file:///home/repo/four.py')
     local result_4 = parser(output_str, bufnr_4)
     local expected_4 = {{
+      source = 'pytest-cov',
       lnum = 0,
       col = 0,
       severity = vim.diagnostic.severity.INFO,
@@ -81,6 +86,7 @@ describe('linter.pytestcov', function()
     local bufnr_5 = vim.uri_to_bufnr('file:///home/repo/four.py')
     local result_5 = parser(errors_launching_tests, bufnr_5)
     local expected_5 = {{
+      source = 'pytest-cov',
       lnum = 0,
       col = 0,
       severity = vim.diagnostic.severity.ERROR,


### PR DESCRIPTION
A long one here! This time for [pytest-cov](https://pypi.org/project/pytest-cov/), which launches pytest to check for test coverage of different files.
I recently saw that there were some implementations about test coverage in vim, so why not bringing then to nvim built-in diagnostics? The CLI output is the next one:
```bash
plugins: typeguard-2.13.3, cov-3.0.0, pylama-8.3.3, cases-3.6.7, harvest-1.10.3
collected 3 items                                                                                                                                                                                                 

tests/mymodule/test_additions.py ...                                                                                                                                                                        [100%]

---------- coverage: platform linux, python 3.8.10-final-0 -----------
Name                               Stmts   Miss  Cover   Missing
----------------------------------------------------------------
main.py                                9      9     0%   1-14
myapp/__init__.py                      0      0   100%
myapp/app.py                           5      5     0%   1-9
myapp/mymodule/__init__.py             0      0   100%
myapp/mymodule/funcs.py                4      1    75%   4
tests/__init__.py                      0      0   100%
tests/mymodule/__init__.py             0      0   100%
tests/mymodule/test_additions.py       6      0   100%
----------------------------------------------------------------
TOTAL                                 24     15    38%

```
Here is the output. If something is not clear (messages, severities...) it can be also changed of course:

When no test coverage is found for a given file:
![pytestcov_notesting](https://user-images.githubusercontent.com/67102627/148522092-b7a6c013-d0d0-4878-b5f2-65c522d12f67.png)

When it is found, but some lines were not tested:
![pytestcov_50](https://user-images.githubusercontent.com/67102627/148522186-9a694556-85ed-415d-95bc-43fbb0bb72a7.png)

When the file could not be tested due to errors
![pytestcov_errors](https://user-images.githubusercontent.com/67102627/148522253-0a57e95d-2515-461a-904f-cdf248da665a.png)

However, there are a few things related to it. Some of them as general comments and some of them as opinion:
- In case the user disables the underline, I added a new commit in which the message include "(until X line)" to know where the non-tested block ends.
- About the underline, it starts to be really annoying in large code scripts. I was thinking about disabling it by default (ie set the col diagnostics to 0). Opinions? :) 
- Since there is now way to know which tests test which scripts, `pytest` will launch all tests in the given directory.