### PR TITLE
fix: better information retrieved pylint and codespell

### DIFF
--- a/lua/lint/linters/codespell.lua
+++ b/lua/lint/linters/codespell.lua
@@ -5,6 +5,7 @@ return {
   ignore_exitcode = true,
   parser = require('lint.parser').from_errorformat(
     '%f:%l:%m',
-    { severity = vim.diagnostic.severity.INFO }
+    { severity = vim.diagnostic.severity.INFO,
+      source = 'codespell'}
   )
 }

--- a/lua/lint/linters/pylint.lua
+++ b/lua/lint/linters/pylint.lua
@@ -16,6 +16,7 @@ return {
     local diagnostics = {}
     local buffer_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":~:.")
 
+    output = string.gsub(output, "message%-id", "message_id")
     for _, item in ipairs(vim.fn.json_decode(output) or {}) do
       if not item.path or vim.fn.fnamemodify(item.path, ":~:.") == buffer_path then
         local column = 0
@@ -23,12 +24,14 @@ return {
           column = item.column - 1
         end
         table.insert(diagnostics, {
+          source = 'pylint',
           lnum = item.line - 1,
           col = column,
           end_lnum = item.line - 1,
           end_col = column,
           severity = assert(severities[item.type], 'missing mapping for severity ' .. item.type),
           message = item.message,
+          code = item.message_id,
         })
       end
     end

--- a/lua/lint/linters/pylint.lua
+++ b/lua/lint/linters/pylint.lua
@@ -16,7 +16,6 @@ return {
     local diagnostics = {}
     local buffer_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":~:.")
 
-    output = string.gsub(output, "message%-id", "message_id")
     for _, item in ipairs(vim.fn.json_decode(output) or {}) do
       if not item.path or vim.fn.fnamemodify(item.path, ":~:.") == buffer_path then
         local column = 0
@@ -31,7 +30,11 @@ return {
           end_col = column,
           severity = assert(severities[item.type], 'missing mapping for severity ' .. item.type),
           message = item.message,
-          code = item.message_id,
+          user_data = {
+            lsp = {
+              code = item['message-id'],
+            },
+          },
         })
       end
     end

--- a/tests/pylint_spec.lua
+++ b/tests/pylint_spec.lua
@@ -50,7 +50,11 @@ describe('linter.pylint', function()
       end_lnum = 3,
       end_col = 0,
       severity = vim.diagnostic.severity.WARN,
-      code = 'W0311',
+      user_data = {
+        lsp = {
+          code = 'W0311',
+        },
+      },
     }
 
     assert.are.same(expected_1, result[1])
@@ -63,7 +67,11 @@ describe('linter.pylint', function()
       end_lnum = 0,
       end_col = 0,
       severity = vim.diagnostic.severity.HINT,
-      code = 'C0114',
+      user_data = {
+        lsp = {
+          code = 'C0114',
+        },
+      },
     }
 
     assert.are.same(expected_2, result[2])
@@ -76,7 +84,11 @@ describe('linter.pylint', function()
       end_lnum = 2,
       end_col = 2,
       severity = vim.diagnostic.severity.INFO,
-      code = 'R0124',
+      user_data = {
+        lsp = {
+          code = 'R0124',
+        },
+      },
     }
 
     assert.are.same(expected_3, result[3])

--- a/tests/pylint_spec.lua
+++ b/tests/pylint_spec.lua
@@ -43,34 +43,40 @@ describe('linter.pylint', function()
     assert.are.same(3, #result)
 
     local expected_1 = {
+      source = 'pylint',
       message = 'Bad indentation. Found 2 spaces, expected 4',
       lnum = 3,
       col = 0,
       end_lnum = 3,
       end_col = 0,
       severity = vim.diagnostic.severity.WARN,
+      code = 'W0311',
     }
 
     assert.are.same(expected_1, result[1])
 
     local expected_2 = {
+      source = 'pylint',
       message = 'Missing module docstring',
       lnum = 0,
       col = 0,
       end_lnum = 0,
       end_col = 0,
       severity = vim.diagnostic.severity.HINT,
+      code = 'C0114',
     }
 
     assert.are.same(expected_2, result[2])
 
     local expected_3 = {
+      source = 'pylint',
       message = 'Redundant comparison - 1 == 1',
       lnum = 2,
       col = 2,
       end_lnum = 2,
       end_col = 2,
       severity = vim.diagnostic.severity.INFO,
+      code = 'R0124',
     }
 
     assert.are.same(expected_3, result[3])


### PR DESCRIPTION
Just a small PR. Since I use Trouble to look at the diagnostics, I could not see some of the information that some linters are supposed to retrieve.
I guess that the previous implementation of Pylint did not read the `message-id` because it was not possible. It seems that, in order to read a value from a lua table, all the keys have to be valid identifiers (which means no hyphens are allowed). Due to this I replaced `message-id`by `message_id`. Thanks to it it was possible to be read.

There might be more linters without this info, but I do not want to modify those that I cannot test. These are the oens I verified:
```  
python = {'flake8', 'mypy', 'pylint', 'vulture', 'codespell', 'pytestcov'},
cpp = {'cppcheck', 'clangtidy', 'cpplint', 'codespell'},
rst = {'rstlint', 'rstcheck', 'proselint', 'codespell'},
markdown = {'markdownlint', 'codespell', 'proselint'},
yaml = {'yamllint', 'codespell', 'proselint'},
cmake = {'cmakelint'},
vim = {'vint'},
```

Before
![pylint_before](https://user-images.githubusercontent.com/67102627/148573600-c3ff7427-1881-48c6-9bd0-f016b02697c9.png)
After
![pylint_after](https://user-images.githubusercontent.com/67102627/148573609-d4c96395-46f6-4947-8d6d-b3937ffa56db.png)

