### PR TITLE
Add phpcs linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Other dedicated linters that are built-in are:
 | [mlint][34]                  | `mlint`        |
 | [Mypy][11]                   | `mypy`         |
 | nix                          | `nix`          |
+| [phpcs][phpcs]               | `phpcs`        |
 | [proselint][proselint]       | `proselint`    |
 | [pycodestyle][pcs-docs]      | `pycodestyle`  |
 | [pydocstyle][pydocstyle]     | `pydocstyle`   |
@@ -291,3 +292,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [rstcheck]: https://github.com/myint/rstcheck
 [rstlint]: https://github.com/twolfson/restructuredtext-lint
 [ktlint]: https://github.com/pinterest/ktlint
+[phpcs]: https://github.com/squizlabs/PHP_CodeSniffer

--- a/lua/lint/linters/phpcs.lua
+++ b/lua/lint/linters/phpcs.lua
@@ -1,0 +1,38 @@
+local severities = {
+  ERROR = vim.diagnostic.severity.ERROR,
+  WARNING = vim.diagnostic.severity.WARN,
+}
+
+return {
+  cmd = 'phpcs',
+  stdin = true,
+  args = {
+    '-q',
+    '--report=json',
+    '-', -- need `-` at the end for stdin support
+  },
+  ignore_exitcode = true,
+  parser = function(output, _)
+    if vim.trim(output) == '' then
+      return {}
+    end
+
+    local decoded = vim.fn.json_decode(output)
+    local diagnostics = {}
+    local messages = decoded['files']['STDIN']['messages']
+
+    for _, msg in ipairs(messages or {}) do
+      table.insert(diagnostics, {
+        lnum = msg.line - 1,
+        end_lnum = msg.line - 1,
+        col = msg.column - 1,
+        end_col = msg.column - 1,
+        message = msg.message,
+        source = 'phpcs',
+        severity = assert(severities[msg.type], 'missing mapping for severity ' .. msg.type),
+      })
+    end
+
+    return diagnostics
+  end
+}

--- a/tests/phpcs_spec.lua
+++ b/tests/phpcs_spec.lua
@@ -1,0 +1,99 @@
+describe('linter.phpcs', function()
+  it('ignores empty output', function()
+    local parser = require('lint.linters.phpcs').parser
+
+    assert.are.same({}, parser('', vim.api.nvim_get_current_buf()))
+    assert.are.same({}, parser('  ', vim.api.nvim_get_current_buf()))
+  end)
+
+  it('parses json output correctly', function()
+    local parser = require('lint.linters.phpcs').parser
+    -- json sourced from sample here: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting#printing-a-json-report
+    -- slightly modified for STDIN result format
+    local result = parser([[
+{
+  "totals": {
+    "errors": 4,
+    "warnings": 1,
+    "fixable": 3
+  },
+  "files": {
+    "STDIN": {
+      "errors": 4,
+      "warnings": 1,
+      "messages": [
+        {
+          "message": "Missing file doc comment",
+          "source": "PEAR.Commenting.FileComment.Missing",
+          "severity": 5,
+          "type": "ERROR",
+          "line": 2,
+          "column": 1,
+          "fixable": false
+        },
+        {
+          "message": "TRUE, FALSE and NULL must be lowercase; expected \"false\" but found \"FALSE\"",
+          "source": "Generic.PHP.LowerCaseConstant.Found",
+          "severity": 5,
+          "type": "ERROR",
+          "line": 4,
+          "column": 12,
+          "fixable": true
+        },
+        {
+          "message": "Line indented incorrectly; expected at least 4 spaces, found 1",
+          "source": "PEAR.WhiteSpace.ScopeIndent.Incorrect",
+          "severity": 5,
+          "type": "ERROR",
+          "line": 6,
+          "column": 2,
+          "fixable": true
+        },
+        {
+          "message": "Missing function doc comment",
+          "source": "PEAR.Commenting.FunctionComment.Missing",
+          "severity": 5,
+          "type": "ERROR",
+          "line": 9,
+          "column": 1,
+          "fixable": false
+        },
+        {
+          "message": "Inline control structures are discouraged",
+          "source": "Generic.ControlStructures.InlineControlStructure.Discouraged",
+          "severity": 5,
+          "type": "WARNING",
+          "line": 11,
+          "column": 5,
+          "fixable": true
+        }
+      ]
+    }
+  }
+}
+    ]], vim.api.nvim_get_current_buf())
+    assert.are.same(5, #result)
+
+    local expected = {
+      lnum = 1,
+      end_lnum = 1,
+      col = 0,
+      end_col = 0,
+      message = 'Missing file doc comment',
+      source = 'phpcs',
+      severity = vim.diagnostic.severity.ERROR
+    }
+    assert.are.same(expected, result[1])
+
+    expected = {
+      lnum = 10,
+      end_lnum = 10,
+      col = 4,
+      end_col = 4,
+      message = 'Inline control structures are discouraged',
+      source = 'phpcs',
+      severity = vim.diagnostic.severity.WARN,
+    }
+    assert.are.same(expected, result[5])
+  end)
+end)


### PR DESCRIPTION
First - thanks for this plugin! Switched over from `ale` recently and am loving the speed this plugin has.

Was in need of a `phpcs` lint integration, so I wrote my own. This integration works locally, but this is my first time writing Lua so am happy to implement any suggestions 😄

Edit: Looks like the Github Actions won't run automatically, but I did run the tests I added locally and they did pass.