### PR TITLE
Read file content instead expecting input from stdin.

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -7,7 +7,7 @@ local severities = {
 
 return {
   cmd = 'golangci-lint',
-  stdin = true,
+  append_fname = true,
   args = {
     'run',
     '--out-format',


### PR DESCRIPTION
Current configuration for `golangci-lint` doesn't seem work, since reading file content from STDIN is not supported.
Set `append_fname` to true so that the command would look like

```
golangci-lint --output-format=json <current-filename>
```

This is fix to #167