### PR TITLE
golangci-lint: appending file breaks some linters

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -7,7 +7,7 @@ local severities = {
 
 return {
   cmd = 'golangci-lint',
-  append_fname = true,
+  append_fname = false,
   args = {
     'run',
     '--out-format',


### PR DESCRIPTION
Appending files means that some linters consider only the contents of the given file when linting it. This is a problem as those linters will not be able to find symbols defined in other files in the same package. `typecheck` is the easiest linter to verify as it will claim that types defined on other files couldn't be found.