### PR TITLE
Ensure column and line numbers remain >= 0

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -32,10 +32,10 @@ return {
         -- only publish if those are the current file diagnostics
         local sv = severities[item.Severity] or severities.warning
         table.insert(diagnostics, {
-          lnum = item.Pos.Line - 1,
-          col = item.Pos.Column - 1,
-          end_lnum = item.Pos.Line - 1,
-          end_col = item.Pos.Column - 1,
+          lnum = item.Pos.Line > 0 and item.Pos.Line - 1 or 0,
+          col = item.Pos.Column > 0 and item.Pos.Column - 1 or 0,
+          end_lnum = item.Pos.Line > 0 and item.Pos.Line - 1 or 0,
+          end_col = item.Pos.Column > 0 and item.Pos.Column - 1 or 0,
           severity = sv,
           source = item.FromLinter,
           message = item.Text,


### PR DESCRIPTION
Some of the linters available with golangci-lint return 0 as a column
value if the issue affects the whole line. The golangci-lint integration
in nvim-lint then subtracts 1, which leads to a negative number.

Newer versions of Neovim treat this as invalid. The result is an error
when trying to jump to that line using `vim.diagnostic.goto_next()`.

This commit ensures that any column or line numbers always remain >= 0.

Closes #176