### PR TITLE
Add linter for lacheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Other dedicated linters that are built-in are:
 | [Inko][17]                   | `inko`         |
 | [jshint][jshint]             | `jshint`       |
 | [ktlint][ktlint]             | `ktlint`       |
+| [lacheck][lacheck]           | `lacheck`      |
 | [Languagetool][5]            | `languagetool` |
 | [luacheck][19]               | `luacheck`     |
 | [markdownlint][26]           | `markdownlint` |
@@ -308,3 +309,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [rstlint]: https://github.com/twolfson/restructuredtext-lint
 [ktlint]: https://github.com/pinterest/ktlint
 [phpcs]: https://github.com/squizlabs/PHP_CodeSniffer
+[lacheck]: https://www.ctan.org/tex-archive/support/lacheck

--- a/lua/lint/linters/lacheck.lua
+++ b/lua/lint/linters/lacheck.lua
@@ -1,0 +1,15 @@
+-- path/to/file, line <linum>: <message>
+local pattern = '[^:]+, line (%d+):(.+)'
+local groups = { 'lnum', 'message' }
+
+return {
+  cmd = 'lacheck',
+  stdin = false,
+  args = {},
+  stream = stdout,
+  ignore_exitcode = false,
+  parser = require('lint.parser').from_pattern(pattern, groups, nil, {
+    ["source"] = "lacheck",
+    ['severity'] = vim.diagnostic.severity.WARN,
+  }),
+}

--- a/lua/lint/linters/lacheck.lua
+++ b/lua/lint/linters/lacheck.lua
@@ -6,7 +6,7 @@ return {
   cmd = 'lacheck',
   stdin = false,
   args = {},
-  stream = stdout,
+  stream = 'stdout',
   ignore_exitcode = false,
   parser = require('lint.parser').from_pattern(pattern, groups, nil, {
     ["source"] = "lacheck",


### PR DESCRIPTION
Create a new linter that parses the outputs of lacheck, a linter for
LaTeX files. This linter only returns line number and a message through
stdout by passing the .tex file as input. lacheck is not capable of
getting the input through stdin.