### PR TITLE
staticcheck: Exclude errors other than current buffer errors

### DIFF
--- a/lua/lint/linters/staticcheck.lua
+++ b/lua/lint/linters/staticcheck.lua
@@ -11,11 +11,13 @@ return {
     '-f', 'json',
   },
   ignore_exitcode = true,
-  parser = function(output)
+  parser = function(output, bufnr)
     local result = vim.fn.split(output, "\n")
+    local bufname = vim.api.nvim_buf_get_name(bufnr)
     local diagnostics = {}
     for _, message in ipairs(result) do
       local decoded = vim.json.decode(message)
+      if decoded.location.file == bufname then
         table.insert(diagnostics, {
           lnum = decoded.location.line - 1,
           col = decoded.location.column - 1,
@@ -30,6 +32,7 @@ return {
           severity = assert(severities[decoded.severity], 'missing mapping for severity ' .. decoded.severity),
           message = decoded.message,
         })
+      end
     end
     return diagnostics
   end,

--- a/tests/staticcheck_spec.lua
+++ b/tests/staticcheck_spec.lua
@@ -1,0 +1,47 @@
+describe('linter.staticcheck', function()
+  it('can parse the output', function()
+    local parser = require('lint.linters.staticcheck').parser
+    local bufnr = vim.uri_to_bufnr('file:///main.go')
+    local result = parser([[
+{"code":"S1001","severity":"error","location":{"file":"/main.go","line":8,"column":2},"end":{"file":"/main.go","line":8,"column":23},"message":"should use copy() instead of a loop"}
+{"code":"S1002","severity":"error","location":{"file":"/main.go","line":13,"column":5},"end":{"file":"/main.go","line":13,"column":14},"message":"should omit comparison to bool constant, can be simplified to x"}
+{"code":"S1002","severity":"error","location":{"file":"/sub.go","line":7,"column":5},"end":{"file":"/sub.go","line":7,"column":14},"message":"should omit comparison to bool constant, can be simplified to y"}
+]], bufnr)
+
+    assert.are.same(2, #result)
+
+    local expected_error_1 = {
+      code = 'S1001',
+      col = 1,
+      end_col = 22,
+      end_lnum = 7,
+      lnum = 7,
+      message = 'should use copy() instead of a loop',
+      severity = 1,
+      user_data = {
+        lsp = {
+          code = 'S1001'
+        }
+      }
+    }
+
+    assert.are.same(expected_error_1, result[1])
+
+    local expected_error_2 = {
+      code = 'S1002',
+      col = 4,
+      end_col = 13,
+      end_lnum = 12,
+      lnum = 12,
+      message = 'should omit comparison to bool constant, can be simplified to x',
+      severity = 1,
+      user_data = {
+        lsp = {
+          code = 'S1002'
+        }
+      }
+    }
+
+    assert.are.same(expected_error_2, result[2])
+  end)
+end)


### PR DESCRIPTION
Regarding the check result of staticcheck, since errors other than the current buffer is also displayed, it was changed to exclude errors other than the current buffer.

### How to reproduce the issue

After making advance preparations, open main.go with Neovim loaded with nvim-lint plugin.

<details>
<summary>Advance preparation</summary>

```sh
$ mkdir example-code
$ cd example-code/
$ vi main.go
$ vi sub.go
$ go mod init example.com/example-code
$ staticcheck
```

main.go

```go
package main

import "fmt"

func main() {
	src := [...]string{"a", "b", "c"}
	var dst []string
	for i, x := range src {
		dst[i] = x
	}

	x := true
	if x == true {
		fmt.Println("main func")
		sub()
	}
}
```

sub.go

```go
package main

import "fmt"

func sub() {
	y := true
	if y == true {
		fmt.Println("sub func")
	}
}
```
</details>

Execution result of staticcheck

```sh
$ staticcheck
main.go:8:2: should use copy() instead of a loop (S1001)
main.go:13:5: should omit comparison to bool constant, can be simplified to x (S1002)
sub.go:7:5: should omit comparison to bool constant, can be simplified to y (S1002)
```

### Expected behavior

Show only errors of main.go.

<img width="929" alt="image" src="https://user-images.githubusercontent.com/7194645/162393488-bc64a3b8-8b5a-45af-ac87-12b7963cdded.png">

### Actual behavior

It also displays errors other than main.go. The error on the 7th line is a error of sub.go.

<img width="931" alt="image" src="https://user-images.githubusercontent.com/7194645/162393352-947a349a-de9a-4f5e-94b2-484b48924633.png">
