### PR TITLE
Call `on_done` callback in `on_exit` handler

### DIFF
--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -100,16 +100,22 @@ end
 
 function M.accumulate_chunks(parse)
   local chunks = {}
+  local already_published = false
   return {
     on_chunk = function(chunk)
       table.insert(chunks, chunk)
     end,
     on_done = function(publish, bufnr)
-      vim.schedule(function()
-        local output = table.concat(chunks)
-        local diagnostics = parse(output, bufnr)
-        publish(diagnostics, bufnr)
-      end)
+      if already_published then
+        return
+      else
+        already_published = true
+        vim.schedule(function()
+          local output = table.concat(chunks)
+          local diagnostics = parse(output, bufnr)
+          publish(diagnostics, bufnr)
+        end)
+      end
     end,
   }
 end


### PR DESCRIPTION
This works around an issue where the `on_done` callback was not always
called by the `read_output` function.

The most likely cause for this is that some linters do not generate an
EOF (that luv detects), therefore never triggering the `else` branch in
`read_output`.

The `on_done` is now called in two places:

  1. The existing `read_output` branch
  2. The `on_exit` handler

`on_done` has been extended to detect if it has already been called and
do nothing on the second invocation.

Closes #185