### PR TITLE
Update golangcilint to read output from stdout and stderr

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -13,7 +13,7 @@ return {
     '--out-format',
     'json',
   },
-  stream = 'stdout',
+  stream = 'both',
   ignore_exitcode = true,
   parser = function(output, bufnr)
     if output == '' then


### PR DESCRIPTION
Fix for #203 

My understanding of the problem is that golangci-lint ouputs the EOF to stdout, and the actual errors to stderr, so this updates the stream to be both. I also changed it to append the filename since some go projects can be pretty large, but happy to take this part out since the user can also set this themselves if they'd like.