### PR TITLE
Fix fennel not being overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Other dedicated linters that are built-in are:
 | [cspell][36]                 | `cspell`       |
 | [ESLint][25]                 | `eslint`       |
 | fennel                       | `fennel`       |
+| fish                         | `fish`         |
 | [Flake8][13]                 | `flake8`       |
 | [flawfinder][35]             | `flawfinder`   |
 | [Golangci-lint][16]          | `golangcilint` |

--- a/lua/lint/linters/fennel.lua
+++ b/lua/lint/linters/fennel.lua
@@ -1,14 +1,8 @@
 local efm = "%C%[%^^]%#,%E%>Parse error in %f:%l,%E%>Compile error in %f:%l,%-Z%p^%.%#,%C%m,%-G* %.%#"
 
-local M
-
-local function globals()
-    return table.concat(M.globals, ",")
-end
-
-M = {
+return {
     cmd = "fennel",
-    args = { "--globals", globals, "--compile" },
+    args = { "--compile" },
     stdin = false,
     ignore_exitcode = true,
     stream = "stderr",
@@ -16,10 +10,4 @@ M = {
         source = "fennel",
         severity = vim.diagnostic.severity.ERROR,
     }),
-
-    -- Users can modify this list like this:
-    --  require("lint.linters.fennel").globals = { "foo", "bar" }
-    globals = {},
 }
-
-return M


### PR DESCRIPTION
Adding globals using the `globals` field did not work, the table was
empty in the function even when
`require("lint.linters.fennel").globals` was changed before setting
`require("lint").linters_by_ft.fennel = { "fennel" }`. After
this, the user can use the `args` field directly to change globals

Adding any other compiler argument using the `args` field did not work
either