### PR TITLE
feat: add glslc

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Other dedicated linters that are built-in are:
 | [Flake8][13]                 | `flake8`       |
 | [flawfinder][35]             | `flawfinder`   |
 | [Golangci-lint][16]          | `golangcilint` |
+| [glslc][glslc]               | `glslc`        |
 | [hadolint][28]               | `hadolint`     |
 | [hlint][32]                  | `hlint`        |
 | [HTML Tidy][12]              | `tidy`         |
@@ -312,3 +313,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [phpcs]: https://github.com/squizlabs/PHP_CodeSniffer
 [lacheck]: https://www.ctan.org/tex-archive/support/lacheck
 [credo]: https://github.com/rrrene/credo
+[glslc]: https://github.com/google/shaderc

--- a/lua/lint/linters/glslc.lua
+++ b/lua/lint/linters/glslc.lua
@@ -1,0 +1,18 @@
+-- path/to/file:line: severity: 'offending part of source code': message
+local pattern = "%s*([^:]+):(%d+): (.+): (.+: .+)"
+local groups = { "file", "lnum", "severity", "message" }
+
+return {
+  cmd = "glslc",
+  stdin = false,
+  args = {"-o", "-"}, -- "-" represents output of compilation result to stdout
+  ignore_exitcode = true,
+  stream = "stderr",
+  parser = require("lint.parser").from_pattern(pattern, groups, {
+    error = vim.diagnostic.severity.ERROR,
+    warning = vim.diagnostic.severity.WARN,
+  }, {
+      ["source"] = "glslc",
+      ["severity"] = vim.diagnostic.severity.WARN,
+    }),
+}


### PR DESCRIPTION
WIP: because this linter requires a output file. Also it can only guess the type of the shader when shader has typical file extension like `*.vert` `*.frag` or a pragma in the shader (https://github.com/google/shaderc/tree/main/glslc#311-shader-stage-specification)