### PR TITLE
ruby: Do not pass nil to nvim_buf_get_name

### DIFF
--- a/lua/lint/linters/ruby.lua
+++ b/lua/lint/linters/ruby.lua
@@ -25,10 +25,10 @@ return {
   args = { '-w', '-c' },
   ignore_exitcode = true,
   stream = 'stderr',
-  parser = function(output)
+  parser = function(output, bufnr)
     local diagnostics = {}
     for _, parser in ipairs(parsers) do
-      local result = parser(output)
+      local result = parser(output, bufnr)
       for _, diagnostic in ipairs(result) do
         table.insert(diagnostics, diagnostic)
       end

--- a/tests/ruby_spec.lua
+++ b/tests/ruby_spec.lua
@@ -1,0 +1,50 @@
+describe('linter.ruby', function()
+  it('can parse the output', function()
+    local parser = require('lint.linters.ruby').parser
+    local bufnr = vim.uri_to_bufnr('file:///foo.rb')
+    local output = [[
+/foo.rb:2: warning: key :bar is duplicated and overwritten on line 2
+/foo.rb:2: warning: unused literal ignored
+/foo.rb:3: syntax error, unexpected end-of-input
+]]
+    local result = parser(output, bufnr)
+
+    assert.are.same(3, #result)
+
+    local expected_warning_1 = {
+      col = 0,
+      end_col = 0,
+      end_lnum = 1,
+      lnum = 1,
+      message = 'key :bar is duplicated and overwritten on line 2',
+      severity = 2,
+      source = 'ruby',
+    }
+
+    assert.are.same(expected_warning_1, result[1])
+
+    local expected_warning_2 = {
+      col = 0,
+      end_col = 0,
+      end_lnum = 1,
+      lnum = 1,
+      message = 'unused literal ignored',
+      severity = 2,
+      source = 'ruby',
+    }
+
+    assert.are.same(expected_warning_2, result[2])
+
+    local expected_error_1 = {
+      col = 0,
+      end_col = 0,
+      end_lnum = 2,
+      lnum = 2,
+      message = 'unexpected end-of-input',
+      severity = 1,
+      source = 'ruby',
+    }
+
+    assert.are.same(expected_error_1, result[3])
+  end)
+end)


### PR DESCRIPTION
Since the execution of ruby linter fails due to the breaking change of Neovim 0.7, I made it explicit to pass `bufnr` as an argument.

### How to reproduce the issue

When I run ruby linter with nvim-lint plugin on Neovim 0.7, I get the following error:

```
Error executing vim.schedule lua callback: .../.local/share/nvim/plugged/nvim-lint/lua/lint/parser.lua:89: Expected Lua number
stack traceback:
        [C]: in function 'nvim_buf_get_name'
        .../.local/share/nvim/plugged/nvim-lint/lua/lint/parser.lua:89: in function 'parser'
        ...l/share/nvim/plugged/nvim-lint/lua/lint/linters/ruby.lua:31: in function 'parse'
        .../.local/share/nvim/plugged/nvim-lint/lua/lint/parser.lua:110: in function <.../.local/share/nvim/plugged/nvim-lint/lua/lint/parser.lua:108>
```

### Cause of issue

In Neovim 0.7, when passing `nil` to `nvim_buf_get_name`, it no longer implicitly converts to `0`.

* ref. https://github.com/neovim/neovim/issues/14090#issuecomment-1004318147

When I checked the ruby linter setting, `nil` was passed to `nvim_buf_get_name` because `bufnr` was not passed as an argument to the following function that returns the parsing result.

https://github.com/mfussenegger/nvim-lint/blob/48067bda493897488047763a863da1683e29e490/lua/lint/parser.lua#L87-L89