### PR TITLE
Case-insensitive severity value in `from_errorformat()`

### DIFF
--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -23,7 +23,7 @@ function M.from_errorformat(efm, skeleton)
         local col = math.max(0, item.col - 1)
         local end_lnum = item.end_lnum > 0 and (item.end_lnum - 1) or lnum
         local end_col = item.end_col > 0 and (item.end_col - 1) or col
-        local severity = item.type ~= "" and severity_by_qftype[item.type] or nil
+        local severity = item.type ~= "" and severity_by_qftype[item.type:upper()] or nil
         local diagnostic = {
           lnum = lnum,
           col = col,


### PR DESCRIPTION
`:h errorformat` doesn't indicate a preference/requirement for capital-letter error types:

```
%t		error type (finds a single character):
		    e - error message
		    w - warning message
		    i - info message
		    n - note message
```

This ended up being relevant to a linter I was developing, so I thought I would submit this trivial fix.