### PR TITLE
Fix pylint: missing mapping for severity info

### DIFF
--- a/lua/lint/linters/pylint.lua
+++ b/lua/lint/linters/pylint.lua
@@ -3,6 +3,7 @@ local severities = {
   fatal = vim.diagnostic.severity.ERROR,
   warning = vim.diagnostic.severity.WARN,
   refactor = vim.diagnostic.severity.INFO,
+  info = vim.diagnostic.severity.INFO,
   convention = vim.diagnostic.severity.HINT,
 }
 


### PR DESCRIPTION
In some python files I was getting this error:

```
Error executing vim.schedule lua callback: ...vim/site/pack/all/start/lint/lua/lint/linters/pylint.lua:32: missing mapping for severity info
stack traceback:
        [C]: in function 'assert'
        ...vim/site/pack/all/start/lint/lua/lint/linters/pylint.lua:32: in function 'parse'
        .../share/nvim/site/pack/all/start/lint/lua/lint/parser.lua:110: in function <.../share/nvim/site/pack/all/start/lint/lua/lint/parser.lua:108>
```

Fixed it locally by adding the `info` severity.

Checked the man page for the `info` severity but didn't find any, but I found [in the online documentation](https://pylint.pycqa.org/en/latest/user_guide/messages/messages_overview.html#information-category).

My pylint version (under Arch Linux):

```
> pylint --version
pylint 2.13.8
astroid 2.11.5
Python 3.10.4 (main, May 14 2022, 05:21:19) [GCC 12.1.0]
```