### PR TITLE
feat: add rubocop linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Other dedicated linters that are built-in are:
 | [robocop][robocop]           | `robocop`      |
 | [rstcheck][rstcheck]         | `rstcheck`     |
 | [rstlint][rstlint]           | `rstlint`      |
+| [RuboCop][rubocop]           | `rubocop`      |
 | Ruby                         | `ruby`         |
 | [Selene][31]                 | `selene`       |
 | [ShellCheck][10]             | `shellcheck`   |
@@ -314,3 +315,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [lacheck]: https://www.ctan.org/tex-archive/support/lacheck
 [credo]: https://github.com/rrrene/credo
 [glslc]: https://github.com/google/shaderc
+[rubocop]: https://github.com/rubocop/rubocop

--- a/lua/lint/linters/rubocop.lua
+++ b/lua/lint/linters/rubocop.lua
@@ -1,0 +1,35 @@
+local severity_map = {
+  ['fatal'] = vim.diagnostic.severity.ERROR,
+  ['error'] = vim.diagnostic.severity.ERROR,
+  ['warning'] = vim.diagnostic.severity.WARN,
+  ['convention'] = vim.diagnostic.severity.HINT,
+  ['refactor'] = vim.diagnostic.severity.INFO,
+  ['info'] = vim.diagnostic.severity.INFO,
+}
+
+return {
+  cmd = 'rubocop',
+  stdin = false,
+  args = {'--format', 'json', '--force-exclusion'},
+  ignore_exitcode = true,
+  parser = function(output)
+    local diagnostics = {}
+    local decoded = vim.json.decode(output)
+    local offences = decoded.files[1].offenses
+
+    for _, off in pairs(offences) do
+      table.insert(diagnostics, {
+        source = 'rubocop',
+        lnum = off.location.start_line - 1,
+        col = off.location.start_column - 1,
+        end_lnum = off.location.last_line - 1,
+        end_col = off.location.last_column,
+        severity = severity_map[off.severity],
+        message = off.message,
+        code = off.cop_name
+      })
+    end
+
+    return diagnostics
+  end,
+}

--- a/tests/rubocop_spec.lua
+++ b/tests/rubocop_spec.lua
@@ -1,0 +1,76 @@
+describe('linter.rubocop', function()
+  it('can parse rubocop output', function()
+    local parser = require('lint.linters.rubocop').parser
+    local result = parser([[
+{
+  "files": [
+    {
+      "path": "test.rb",
+      "offenses": [
+        {
+          "severity": "convention",
+          "message": "Use snake_case for method names.",
+          "cop_name": "Naming/MethodName",
+          "corrected": false,
+          "correctable": false,
+          "location": {
+            "start_line": 3,
+            "start_column": 5,
+            "last_line": 3,
+            "last_column": 11,
+            "length": 7,
+            "line": 3,
+            "column": 5
+          }
+        },
+        {
+          "severity": "warning",
+          "message": "Useless assignment to variable - `foo`.",
+          "cop_name": "Lint/UselessAssignment",
+          "corrected": false,
+          "correctable": false,
+          "location": {
+            "start_line": 4,
+            "start_column": 3,
+            "last_line": 4,
+            "last_column": 5,
+            "length": 3,
+            "line": 4,
+            "column": 3
+          }
+        }
+      ]
+    }
+  ]
+}
+]])
+
+    assert.are.same(2, #result)
+
+    local expected_1 = {
+      source = 'rubocop',
+      lnum = 2,
+      col = 4,
+      end_lnum = 2,
+      end_col = 11,
+      severity = vim.diagnostic.severity.HINT,
+      message = 'Use snake_case for method names.',
+      code = 'Naming/MethodName',
+    }
+
+    assert.are.same(expected_1, result[1])
+
+    local expected_2 = {
+      source = 'rubocop',
+      lnum = 3,
+      col = 2,
+      end_lnum = 3,
+      end_col = 5,
+      severity = vim.diagnostic.severity.WARN,
+      message = 'Useless assignment to variable - `foo`.',
+      code = 'Lint/UselessAssignment',
+    }
+
+    assert.are.same(expected_2, result[2])
+  end)
+end)


### PR DESCRIPTION
This PR adds [RuboCop](https://github.com/rubocop/rubocop) linter for Ruby codes.