### PR TITLE
Fix #225: hlint fails with non-zero exit-code unless there are no hints

### DIFF
--- a/lua/lint/linters/hlint.lua
+++ b/lua/lint/linters/hlint.lua
@@ -6,7 +6,7 @@ local severities = {
 
 return {
   cmd = "hlint",
-  args = { "--json" },
+  args = { "--json", "--no-exit-code" },
   parser = function(output)
     local diagnostics = {}
     local items = #output > 0 and vim.json.decode(output) or {}


### PR DESCRIPTION
Fixes #225 