### PR TITLE
Support Hadolint "style" findings.

### DIFF
--- a/lua/lint/linters/hadolint.lua
+++ b/lua/lint/linters/hadolint.lua
@@ -2,6 +2,7 @@ local severities = {
   error = vim.diagnostic.severity.ERROR,
   warning = vim.diagnostic.severity.WARN,
   info = vim.diagnostic.severity.INFO,
+  style = vim.diagnostic.severity.HINT,
 }
 
 return {


### PR DESCRIPTION
Using hadolint 2.10.0

I recently started hitting [this assertion](https://github.com/mfussenegger/nvim-lint/blob/master/lua/lint/linters/hadolint.lua#L23). Manually running `hadolint --format json <dockerfile>` gives a finding with `"level":"style"`.

If this isn't the desired solution for handling this, I'm happy to change it up as necessary.