### PR TITLE
Remove <buffer> from autocmd example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ require('lint').linters_by_ft = {
 Then setup a autocmd to trigger linting. For example:
 
 ```vimL
-au BufWritePost <buffer> lua require('lint').try_lint()
+au BufWritePost lua require('lint').try_lint()
 ```
 
 or with Lua autocmds (requires 0.7):


### PR DESCRIPTION
It's easier to setup a global autocmd instead of one per buffer.

If people copy the example verbatim into their `init.vim` without
knowing what `<buffer>` is for they may get the impression that it
doesn't work.

`try_lint` uses the registered linters (`linters_by_ft` anyways)
