### PR TITLE
Skip parsing result if the buffer is no longer valid

### DIFF
--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -110,7 +110,12 @@ function M.accumulate_chunks(parse)
     on_done = function(publish, bufnr)
       vim.schedule(function()
         local output = table.concat(chunks)
-        local diagnostics = parse(output, bufnr)
+        local diagnostics
+        if vim.api.nvim_buf_is_valid(bufnr) then
+          diagnostics = parse(output, bufnr)
+        else
+          diagnostics = {}
+        end
         publish(diagnostics, bufnr)
       end)
     end,


### PR DESCRIPTION
Some parsers try to access the buffer but fail if it got deleted
in-between. Skipping the parse step saves some CPU cycles and prevents
the errors. The result would be discarded anyways.
