### PR TITLE
Fix column for pylint

### DIFF
--- a/lua/lint/linters/pylint.lua
+++ b/lua/lint/linters/pylint.lua
@@ -20,16 +20,14 @@ return {
 
     for _, item in ipairs(vim.json.decode(output) or {}) do
       if not item.path or vim.fn.fnamemodify(item.path, ":~:.") == buffer_path then
-        local column = 0
-        if item.column > 0 then
-          column = item.column - 1
-        end
+        local column = item.column > 0 and item.column or 0
+        local end_column = item.endColumn ~= vim.NIL and item.endColumn or column
         table.insert(diagnostics, {
           source = 'pylint',
           lnum = item.line - 1,
           col = column,
           end_lnum = item.line - 1,
-          end_col = column,
+          end_col = end_column,
           severity = assert(severities[item.type], 'missing mapping for severity ' .. item.type),
           message = item.message,
           user_data = {

--- a/tests/pylint_spec.lua
+++ b/tests/pylint_spec.lua
@@ -36,11 +36,24 @@ describe('linter.pylint', function()
     "symbol": "comparison-with-itself",
     "message": "Redundant comparison - 1 == 1",
     "message-id": "R0124"
-  }
+  },
+  {
+     "type": "warning",
+     "module": "two",
+     "obj": "",
+     "line": 5,
+     "column": 4,
+     "endLine": 5,
+     "endColumn": 8,
+     "path": "/two.py",
+     "symbol": "unused-variable",
+     "message": "Unused variable 'test'",
+     "message-id": "W0612"
+    }
 ]
 ]], bufnr)
 
-    assert.are.same(3, #result)
+    assert.are.same(4, #result)
 
     local expected_1 = {
       source = 'pylint',
@@ -80,9 +93,9 @@ describe('linter.pylint', function()
       source = 'pylint',
       message = 'Redundant comparison - 1 == 1',
       lnum = 2,
-      col = 2,
+      col = 3,
       end_lnum = 2,
-      end_col = 2,
+      end_col = 3,
       severity = vim.diagnostic.severity.INFO,
       user_data = {
         lsp = {
@@ -92,5 +105,22 @@ describe('linter.pylint', function()
     }
 
     assert.are.same(expected_3, result[3])
+
+    local expected_4 = {
+      source = 'pylint',
+      message = "Unused variable 'test'",
+      lnum = 4,
+      col = 4,
+      end_lnum = 4,
+      end_col = 8,
+      severity = vim.diagnostic.severity.WARN,
+      user_data = {
+        lsp = {
+          code = 'W0612',
+        },
+      },
+    }
+
+    assert.are.same(expected_4, result[4])
   end)
 end)

--- a/tests/pylint_spec.lua
+++ b/tests/pylint_spec.lua
@@ -38,18 +38,18 @@ describe('linter.pylint', function()
     "message-id": "R0124"
   },
   {
-     "type": "warning",
-     "module": "two",
-     "obj": "",
-     "line": 5,
-     "column": 4,
-     "endLine": 5,
-     "endColumn": 8,
-     "path": "/two.py",
-     "symbol": "unused-variable",
-     "message": "Unused variable 'test'",
-     "message-id": "W0612"
-    }
+    "type": "warning",
+    "module": "two",
+    "obj": "",
+    "line": 5,
+    "column": 4,
+    "endLine": 5,
+    "endColumn": 8,
+    "path": "/two.py",
+    "symbol": "unused-variable",
+    "message": "Unused variable 'test'",
+    "message-id": "W0612"
+  }
 ]
 ]], bufnr)
 


### PR DESCRIPTION
I noticed it didn't have any underline/undercurl etc for pylint. This should fix it.

First I tried to just add the end_column, but noticed the starting column was one off.
<img width="868" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/5160701/184416441-fb4bc22b-d58b-47bc-ab8a-9647d4417f94.png">

## Result
<img width="865" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/5160701/184416477-e26a98c2-5264-4770-b281-539c5799782e.png">
