### PR TITLE
sqlfluff: handle non-json output 

### DIFF
--- a/lua/lint/linters/sqlfluff.lua
+++ b/lua/lint/linters/sqlfluff.lua
@@ -8,7 +8,28 @@ return {
   ignore_exitcode = true,
   stdin = true,
   parser = function(output, _)
-    local per_filepath = #output > 0 and vim.json.decode(output) or {}
+    local per_filepath = {}
+    if #output > 0 then
+      local status, decoded = pcall(vim.json.decode, output)
+      if not status then
+        per_filepath = {
+          {
+            filepath = "stdin",
+            violations = {
+              {
+                source = 'sqlfluff',
+                line_no = 1,
+                line_pos = 1,
+                code = 'jsonparsingerror',
+                description = output,
+              },
+            },
+          },
+        }
+      else
+        per_filepath = decoded
+      end
+    end
     local diagnostics = {}
     for _, i_filepath in ipairs(per_filepath) do
       if i_filepath.filepath == "stdin" then -- only process stdin

--- a/tests/sqlfluff_spec.lua
+++ b/tests/sqlfluff_spec.lua
@@ -31,4 +31,17 @@ describe('linter.sqlfluff', function()
     assert.are.same(expected[2], result[2])
 
   end)
+  it("bad CLI args end in non-json output", function()
+    local parser = require('lint.linters.sqlfluff').parser
+    local bufnr = vim.uri_to_bufnr('file:///non-existent.sql')
+    -- when problems are encountered, sqlfluff will report with plain text and
+    -- not a formatted json
+    local status, _ = pcall(parser, [[
+Error: Unknown dialect 'postgresql'
+]], bufnr)
+
+    -- not breaking should be enough, the parsing error is reported as "problem in first line-col"
+    assert(status)
+
+  end)
 end)


### PR DESCRIPTION
when there's a problem running `sqlfluff` _that is not from the input file_ the command will print a non-json text. 

This PR takes care of such problems. The message is reported as "the linter found a problem in the first line-col"