### PR TITLE
[Feature] Add linter option, append_dname

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ require('lint').linters.your_linter_name = {
   cmd = 'linter_cmd',
   stdin = true, -- or false if it doesn't support content input via stdin. In that case the filename is automatically added to the arguments.
   append_fname = true, -- Automatically append the file name to `args` if `stdin = false` (default: true)
+  append_dname = false, -- Automatically append the (file) directory name to `args` if `stdin = false` and `append_fname = false` (default: false)
   args = {}, -- list of arguments. Can contain functions with zero arguments that will be evaluated once the linter is used.
   stream = nil, -- ('stdout' | 'stderr' | 'both') configure the stream to which the linter outputs the linting result.
   ignore_exitcode = false, -- set this to true if the linter exits with a code != 0 and that's considered normal.

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -148,8 +148,12 @@ function M.lint(linter, opts)
   if linter.args then
     vim.list_extend(args, vim.tbl_map(eval_fn_or_id, linter.args))
   end
-  if not linter.stdin and linter.append_fname ~= false then
-    table.insert(args, api.nvim_buf_get_name(bufnr))
+  if not linter.stdin then
+    if linter.append_fname ~= false then
+      table.insert(args, api.nvim_buf_get_name(bufnr))
+    elseif linter.append_dname == true then
+      table.insert(args, vim.fn.fnamemodify(api.nvim_buf_get_name(bufnr), ":h"))
+    end
   end
   if linter.env then
     env = {}

--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -8,6 +8,7 @@ local severities = {
 return {
   cmd = 'golangci-lint',
   append_fname = false,
+  append_dname = true,
   args = {
     'run',
     '--out-format',


### PR DESCRIPTION
Append folder name to `golangci-lint` to lint current package only instead of the entire workspace.