### PR TITLE
Add Tcl/nagelfar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Other dedicated linters that are built-in are:
 | [HTML Tidy][12]                    | `tidy`            |
 | [Inko][17]                         | `inko`            |
 | [jshint][jshint]                   | `jshint`          |
-| [jsonlint][jsonlint]               | `jsonlint`          |
+| [jsonlint][jsonlint]               | `jsonlint`        |
 | [ktlint][ktlint]                   | `ktlint`          |
 | [lacheck][lacheck]                 | `lacheck`         |
 | [Languagetool][5]                  | `languagetool`    |
@@ -121,6 +121,7 @@ Other dedicated linters that are built-in are:
 | [StandardRB][27]                   | `standardrb`      |
 | [statix check][33]                 | `statix`          |
 | [stylelint][29]                    | `stylelint`       |
+| [Tcl][nagelfar]                    | `nagelfar`        |
 | [Vale][8]                          | `vale`            |
 | [vint][21]                         | `vint`            |
 | [vulture][vulture]                 | `vulture`         |
@@ -340,3 +341,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [nix]: https://github.com/NixOS/nix
 [ruby]: https://github.com/ruby/ruby
 [npm-groovy-lint]: https://github.com/nvuillam/npm-groovy-lint
+[nagelfar]: https://nagelfar.sourceforge.net/

--- a/lua/lint/linters/nagelfar.lua
+++ b/lua/lint/linters/nagelfar.lua
@@ -1,0 +1,12 @@
+local pattern = '%f: %l: %t %m,%-GChecking file %f'
+
+return {
+  cmd             = 'nagelfar',
+  args            = {'-H'},
+  append_fname    = true,
+  stdin           = false,
+  stream          = 'both',
+  ignore_exitcode = true,
+  env             = nil,
+  parser          = require('lint.parser').from_errorformat(pattern)
+}


### PR DESCRIPTION
This PR adds support for the Tcl programming language using the Nagelfar syntax analysis tool. 