### PR TITLE
docs: update README to fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Other dedicated linters that are built-in are:
 | [StandardRB][27]                   | `standardrb`      |
 | [statix check][33]                 | `statix`          |
 | [stylelint][29]                    | `stylelint`       |
-| [Tcl][nagelfar]                    | `nagelfar`        |
+| [Nagelfar][nagelfar]               | `nagelfar`        |
 | [Vale][8]                          | `vale`            |
 | [vint][21]                         | `vint`            |
 | [vulture][vulture]                 | `vulture`         |


### PR DESCRIPTION
In my original PR I accidentally put `Tcl` instead of `Nagelfar` for the tool name. This commit corrects that error.