### PR TITLE
rubocop: handle empty files list being returned

### DIFF
--- a/lua/lint/linters/rubocop.lua
+++ b/lua/lint/linters/rubocop.lua
@@ -15,6 +15,11 @@ return {
   parser = function(output)
     local diagnostics = {}
     local decoded = vim.json.decode(output)
+
+    if not decoded.files[1] then
+      return diagnostics
+    end
+
     local offences = decoded.files[1].offenses
 
     for _, off in pairs(offences) do

--- a/tests/rubocop_spec.lua
+++ b/tests/rubocop_spec.lua
@@ -73,4 +73,10 @@ describe('linter.rubocop', function()
 
     assert.are.same(expected_2, result[2])
   end)
+
+  it('can handle rubocop excluding the file', function()
+    local parser = require('lint.linters.rubocop').parser
+    local result = parser([[{ "files": [] }]])
+    assert.are.same(0, #result)
+  end)
 end)


### PR DESCRIPTION
The RuboCop linter's JSON output will always have a "files" key with a list of linted files. nvim-lint looks for the first of these files with `decoded.files[1]`.

Given that nvim-lint passes `--force-exclusion` to the `rubocop` binary, it's entirely possible that the "files" value in the JSON data will be an empty array (`[]`).

With this change, the nvim-lint processing of the RuboCop results will prevent an error by not attempting to access an entry in the "files" array that is not there.

A new test has been added to demonstrate the problem and confirm the fix.

Future ideas:

- make the `--force-exclusion` flag optional
- alert the NeoVim user that the file for the current buffer was excluded, lest they believe that the linter processed the file without finding any issues