### PR TITLE
Add code field to Pylint's diagnostics

### DIFF
--- a/lua/lint/linters/pylint.lua
+++ b/lua/lint/linters/pylint.lua
@@ -30,7 +30,7 @@ return {
           end_col = end_column,
           severity = assert(severities[item.type], 'missing mapping for severity ' .. item.type),
           message = item.message,
-          code = item.symbol,
+          code = item['message-id'],
           user_data = {
             lsp = {
               code = item['message-id'],

--- a/lua/lint/linters/pylint.lua
+++ b/lua/lint/linters/pylint.lua
@@ -30,6 +30,7 @@ return {
           end_col = end_column,
           severity = assert(severities[item.type], 'missing mapping for severity ' .. item.type),
           message = item.message,
+          code = item.symbol,
           user_data = {
             lsp = {
               code = item['message-id'],

--- a/tests/pylint_spec.lua
+++ b/tests/pylint_spec.lua
@@ -63,6 +63,7 @@ describe('linter.pylint', function()
       end_lnum = 3,
       end_col = 0,
       severity = vim.diagnostic.severity.WARN,
+      code = 'bad-indentation',
       user_data = {
         lsp = {
           code = 'W0311',
@@ -80,6 +81,7 @@ describe('linter.pylint', function()
       end_lnum = 0,
       end_col = 0,
       severity = vim.diagnostic.severity.HINT,
+      code = 'missing-module-docstring',
       user_data = {
         lsp = {
           code = 'C0114',
@@ -97,6 +99,7 @@ describe('linter.pylint', function()
       end_lnum = 2,
       end_col = 3,
       severity = vim.diagnostic.severity.INFO,
+      code = 'comparison-with-itself',
       user_data = {
         lsp = {
           code = 'R0124',
@@ -114,6 +117,7 @@ describe('linter.pylint', function()
       end_lnum = 4,
       end_col = 8,
       severity = vim.diagnostic.severity.WARN,
+      code = 'unused-variable',
       user_data = {
         lsp = {
           code = 'W0612',

--- a/tests/pylint_spec.lua
+++ b/tests/pylint_spec.lua
@@ -63,7 +63,7 @@ describe('linter.pylint', function()
       end_lnum = 3,
       end_col = 0,
       severity = vim.diagnostic.severity.WARN,
-      code = 'bad-indentation',
+      code = 'W0311',
       user_data = {
         lsp = {
           code = 'W0311',
@@ -81,7 +81,7 @@ describe('linter.pylint', function()
       end_lnum = 0,
       end_col = 0,
       severity = vim.diagnostic.severity.HINT,
-      code = 'missing-module-docstring',
+      code = 'C0114',
       user_data = {
         lsp = {
           code = 'C0114',
@@ -99,7 +99,7 @@ describe('linter.pylint', function()
       end_lnum = 2,
       end_col = 3,
       severity = vim.diagnostic.severity.INFO,
-      code = 'comparison-with-itself',
+      code = 'R0124',
       user_data = {
         lsp = {
           code = 'R0124',
@@ -117,7 +117,7 @@ describe('linter.pylint', function()
       end_lnum = 4,
       end_col = 8,
       severity = vim.diagnostic.severity.WARN,
-      code = 'unused-variable',
+      code = 'W0612',
       user_data = {
         lsp = {
           code = 'W0612',


### PR DESCRIPTION
The value can be used when rendering diagnostic information. For example, it is used by default in the diagnostic float window since https://github.com/neovim/neovim/pull/21130.

c.f. `:help diagnostic-structure`