### PR TITLE
Corrected typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ defaults = {["source"] = "mylint-name"}
 You can import a linter and modify its properties. An example:
 
 ```lua
-local phpcs = require('lint.linters.phpcs')
+local phpcs = require('lint').linters.phpcs
 phpcs.args = {
   '-q',
   -- <- Add a new parameter here


### PR DESCRIPTION
Corrected a typo in the example provided in the "Customize built-in linter parameters" section in README.md.