### PR TITLE
cspell: Ignore normal error code

### DIFF
--- a/lua/lint/linters/cspell.lua
+++ b/lua/lint/linters/cspell.lua
@@ -1,6 +1,7 @@
 return {
   cmd = 'cspell',
   stdin = true,
+  ignore_exitcode = true,
   args = {
     'lint',
     '--no-color',


### PR DESCRIPTION
Not sure if `cspell` changed behavior or if I just missed this when adding the linter. Either way, this should be all that's needed to fix.