### PR TITLE
tests/compiler_spec: Make Python bin relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ phpcs.args = {
 
 ### Run tests
 
-Running tests requires [plenary.nvim][plenary] to be checked out in the parent directory of *this* repository.
+Running tests requires [plenary.nvim][plenary] to be checked out in the parent directory of *this* repository, as well as `python` resolvable via PATH.
 You can then run:
 
 ```bash

--- a/tests/both.py
+++ b/tests/both.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import sys
 

--- a/tests/compiler_spec.lua
+++ b/tests/compiler_spec.lua
@@ -4,7 +4,7 @@ describe('compiler', function()
     local bufnr = a.nvim_create_buf(true, true)
     a.nvim_set_current_buf(bufnr)
     a.nvim_buf_set_option(bufnr, 'errorformat', '%l: %m')
-    a.nvim_buf_set_option(bufnr, 'makeprg', '/usr/bin/python tests/both.py')
+    a.nvim_buf_set_option(bufnr, 'makeprg', 'python tests/both.py')
 
     require('lint').try_lint('compiler')
 


### PR DESCRIPTION
Use path resolution to allow for testing on systems that may not have `/usr/bin/python` as the path for Python 3. Additionally, alter `both.py` shebang to match.

Added notice of Python test dependency to the README section.

I specifically use NixOS which does not store binaries in `/usr/bin` or `/bin`, and so had this test fail without this fix. Either way, the resolution system in both the `makeprg` variable and the `both.py` shebang should be the same -- absolute or via PATH.