### PR TITLE
fix: statix returns a non-zero exitcode if there are any errors

### DIFF
--- a/lua/lint/linters/statix.lua
+++ b/lua/lint/linters/statix.lua
@@ -3,6 +3,7 @@ return {
   stdin = true,
   args = {'check', '-o', 'errfmt', '--stdin'},
   stream = 'stdout',
+  ignore_exitcode = true, -- statix only returns 0 if there are no errors
   parser = require('lint.parser').from_errorformat('%f>%l:%c:%t:%n:%m', {
     source = 'statix'
   })


### PR DESCRIPTION
`statix` returns a non-zero exitcode if the checked file (or buffer) contains any errors.