### PR TITLE
cancel previously spawned processes ( fix #302 )

### DIFF
--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -171,7 +171,7 @@ function M.try_lint(names, opts)
 
   buffer_to_running_handles[bufnr] = handles
 
-  if not buffer_handles_cleanup_au[bufnr] then
+  if not buffer_handles_cleanup_au[bufnr] and api.nvim_create_autocmd then
     buffer_handles_cleanup_au[bufnr] = api.nvim_create_autocmd("BufDelete", {
       buffer = bufnr,
       desc = string.format("lint cleanup after buffer %d", bufnr),

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -163,8 +163,9 @@ function M.try_lint(names, opts)
       notify(handle_or_error --[[@as string]], vim.log.levels.WARN)
     end
   end
+
   buffer_to_running_handles[bufnr] = handles
-  return {handles = handles}
+
 end
 
 local function eval_fn_or_id(x)

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -163,6 +163,7 @@ function M.try_lint(names, opts)
       notify(handle_or_error --[[@as string]], vim.log.levels.WARN)
     end
   end
+  running_procs_by_buf[bufnr] = running_procs
 end
 
 local function eval_fn_or_id(x)

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -149,7 +149,7 @@ function M.try_lint(names, opts)
   local previous_handles = buffer_to_running_handles[bufnr] or {}
   for _, handle in ipairs(previous_handles) do
     if handle and not handle:is_closing() then
-      handle:close()
+      handle:kill("SIGTERM")
     end
   end
 


### PR DESCRIPTION
store process handles on each `try_lint()` call on a per-buffer basis, cancel processes that are still running on every `try_lint()` call

part 2/2 of #302 