### PR TITLE
Find stylelint in node_modules binaries first

### DIFF
--- a/lua/lint/linters/stylelint.lua
+++ b/lua/lint/linters/stylelint.lua
@@ -4,7 +4,14 @@ local severities = {
 }
 
 return {
-  cmd = "stylelint",
+  cmd = function()
+    local local_stylelint = vim.fn.fnamemodify("./node_modules/.bin/stylelint", ":p")
+    local stat = vim.loop.fs_stat(local_stylelint)
+    if stat then
+      return local_stylelint
+    end
+    return "stylelint"
+  end,
   stdin = true,
   args = {
     "-f",


### PR DESCRIPTION
Same as for ESLint: first try to find stylelint in node_modules binaries, fallback to system stylelint