### PR TITLE
Fix: linters installed by npm doesn't work on Windows

### DIFF
--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -6,7 +6,7 @@ local severity_map = {
   ['warning'] = vim.diagnostic.severity.WARN,
 }
 
-return require('lint.util').call_with_cmd_exe_on_windows {
+return require('lint.util').inject_cmd_exe({
   cmd = function()
     local local_eslint = vim.fn.fnamemodify('./node_modules/.bin/eslint', ':p')
     local stat = vim.loop.fs_stat(local_eslint)
@@ -20,4 +20,4 @@ return require('lint.util').call_with_cmd_exe_on_windows {
   stream = 'stdout',
   ignore_exitcode = true,
   parser = require('lint.parser').from_pattern(pattern, groups, severity_map, { ['source'] = 'eslint' }),
-}
+})

--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -6,7 +6,7 @@ local severity_map = {
   ['warning'] = vim.diagnostic.severity.WARN,
 }
 
-return {
+return require('lint.util').call_with_cmd_exe_on_windows {
   cmd = function()
     local local_eslint = vim.fn.fnamemodify('./node_modules/.bin/eslint', ':p')
     local stat = vim.loop.fs_stat(local_eslint)

--- a/lua/lint/linters/eslint_d.lua
+++ b/lua/lint/linters/eslint_d.lua
@@ -6,7 +6,7 @@ local severity_map = {
   ['warning'] = vim.diagnostic.severity.WARN,
 }
 
-return require('lint.util').call_with_cmd_exe_on_windows {
+return require('lint.util').inject_cmd_exe({
   cmd = function()
     local local_eslintd = vim.fn.fnamemodify('./node_modules/.bin/eslint_d', ':p')
     local stat = vim.loop.fs_stat(local_eslintd)
@@ -20,4 +20,4 @@ return require('lint.util').call_with_cmd_exe_on_windows {
   stream = 'stdout',
   ignore_exitcode = true,
   parser = require('lint.parser').from_pattern(pattern, groups, severity_map, { ['source'] = 'eslint_d' }),
-}
+})

--- a/lua/lint/linters/eslint_d.lua
+++ b/lua/lint/linters/eslint_d.lua
@@ -6,7 +6,7 @@ local severity_map = {
   ['warning'] = vim.diagnostic.severity.WARN,
 }
 
-return {
+return require('lint.util').call_with_cmd_exe_on_windows {
   cmd = function()
     local local_eslintd = vim.fn.fnamemodify('./node_modules/.bin/eslint_d', ':p')
     local stat = vim.loop.fs_stat(local_eslintd)

--- a/lua/lint/linters/stylelint.lua
+++ b/lua/lint/linters/stylelint.lua
@@ -3,7 +3,7 @@ local severities = {
   error = vim.diagnostic.severity.ERROR,
 }
 
-return {
+return require('lint.util').call_with_cmd_exe_on_windows {
   cmd = function()
     local local_stylelint = vim.fn.fnamemodify("./node_modules/.bin/stylelint", ":p")
     local stat = vim.loop.fs_stat(local_stylelint)

--- a/lua/lint/linters/stylelint.lua
+++ b/lua/lint/linters/stylelint.lua
@@ -3,7 +3,7 @@ local severities = {
   error = vim.diagnostic.severity.ERROR,
 }
 
-return require('lint.util').call_with_cmd_exe_on_windows {
+return require('lint.util').inject_cmd_exe({
   cmd = function()
     local local_stylelint = vim.fn.fnamemodify("./node_modules/.bin/stylelint", ":p")
     local stat = vim.loop.fs_stat(local_stylelint)
@@ -64,4 +64,4 @@ return require('lint.util').call_with_cmd_exe_on_windows {
     end
     return diagnostics
   end
-}
+})

--- a/lua/lint/util.lua
+++ b/lua/lint/util.lua
@@ -23,12 +23,11 @@ end
 
 -- Modifies the linter to call linter.cmd via cmd.exe on Windows.
 -- This is necessary for some linters called via their .cmd shim.
-function M.call_with_cmd_exe_on_windows(linter)
-  if vim.fn.has 'win32' ~= 1 then
+function M.inject_cmd_exe(linter)
+  if vim.fn.has('win32') ~= 1 then
     return linter
   end
-
-  return vim.tbl_extend("force", {}, linter, {
+  return vim.tbl_extend("force", linter, {
     cmd = "cmd.exe",
     args = { "/C", linter.cmd, unpack(linter.args) },
   })

--- a/lua/lint/util.lua
+++ b/lua/lint/util.lua
@@ -21,4 +21,18 @@ function M.find_nearest_directory(directory)
 end
 
 
+-- Modifies the linter to call linter.cmd via cmd.exe on Windows.
+-- This is necessary for some linters called via their .cmd shim.
+function M.call_with_cmd_exe_on_windows(linter)
+  if vim.fn.has 'win32' ~= 1 then
+    return linter
+  end
+
+  return vim.tbl_extend("force", {}, linter, {
+    cmd = "cmd.exe",
+    args = { "/C", linter.cmd, unpack(linter.args) },
+  })
+end
+
+
 return M


### PR DESCRIPTION
Problem
====

On Windows, some linters are installed with the shim command suffixed with ".cmd" to run by its interpreter programs (such as Node.js). In such a case, we have to call the shim command to correctly run on Windows, otherwise we get an error like below:

```
Error running eslint_d: ENOENT: no such file or directory
```

Solution
====

Make a wraper around for such linters to call the shim command using cmd.exe.

Note
====

I applied the wrapper function `call_with_cmd_exe_on_windows` to some linters installed by npm in haste. But I guess there is other linters that should be wrapped.

Related change
====

<https://github.com/neovim/nvim-lspconfig/pull/1522>