### PR TITLE
hlint: add suggested change to message

### DIFF
--- a/lua/lint/linters/hlint.lua
+++ b/lua/lint/linters/hlint.lua
@@ -18,7 +18,7 @@ return {
         end_col = item.endColumn,
         severity = severities[item.severity:lower()],
         source = "hlint",
-        message = item.hint .. item.to and (": " .. item.to),
+        message = item.hint .. (item.to and ": " .. item.to or ""),
       })
     end
     return diagnostics

--- a/lua/lint/linters/hlint.lua
+++ b/lua/lint/linters/hlint.lua
@@ -18,7 +18,7 @@ return {
         end_col = item.endColumn,
         severity = severities[item.severity:lower()],
         source = "hlint",
-        message = item.hint .. (item.to and ": " .. item.to or ""),
+        message = item.hint .. (item.to ~= vim.NIL and (": " .. item.to) or ""),
       })
     end
     return diagnostics

--- a/lua/lint/linters/hlint.lua
+++ b/lua/lint/linters/hlint.lua
@@ -18,7 +18,7 @@ return {
         end_col = item.endColumn,
         severity = severities[item.severity:lower()],
         source = "hlint",
-        message = item.hint,
+        message = item.hint .. item.to and (": " .. item.to),
       })
     end
     return diagnostics

--- a/tests/hlint_spec.lua
+++ b/tests/hlint_spec.lua
@@ -40,7 +40,7 @@ describe("linter.hlint", function()
       end_col = 17,
       severity = vim.diagnostic.severity.WARN,
       source = "hlint",
-      message = "Use concatMap",
+      message = "Use concatMap: concatMap f x",
     }
     assert.are.same(result[1], expected)
   end)


### PR DESCRIPTION
The current implementation only shows the summary for hlint.

This adds the suggested change to the diagnostic message.

Before:

```haskell
concat $ map escapeC s -- Use concatMap
```

After:

```haskell
concat $ map escapeC s -- Use concatMap: concatMap escapeC s
```