### PR TITLE
Add Linux kernel's checkpatch.pl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Other dedicated linters that are built-in are:
 | [buf_lint][buf_lint]               | `buf_lint`        |
 | [cfn-lint][cfn-lint]               | `cfn_lint`        |
 | [cfn_nag][cfn_nag]                 | `cfn_nag`         |
+| [checkpatch.pl][checkpatch]        | `checkpatch`      |
 | [checkstyle][checkstyle]           | `checkstyle`      |
 | [chktex][20]                       | `chktex`          |
 | [clang-tidy][23]                   | `clangtidy`       |
@@ -332,6 +333,7 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [ansible-lint]: https://docs.ansible.com/lint.html
 [pcs-docs]: https://pycodestyle.pycqa.org/en/latest/
 [pydocstyle]: https://www.pydocstyle.org/en/stable/
+[checkpatch]: https://docs.kernel.org/dev-tools/checkpatch.html
 [checkstyle]: https://checkstyle.sourceforge.io/
 [jshint]: https://jshint.com/
 [jsonlint]: https://github.com/zaach/jsonlint

--- a/lua/lint/linters/checkpatch.lua
+++ b/lua/lint/linters/checkpatch.lua
@@ -1,0 +1,27 @@
+-- The scripts/ directory of the Linux kernel tree needs to be in your PATH or
+-- the full path to the checkpatch.pl script can be overriden from user config:
+-- require("lint").linters.checkpatch.cmd = '…/checkpatch.pl'
+
+-- path/to/file:line: severity: message
+local pattern = '([^:]+):(%d+): (%a+): (.+)'
+local groups = { 'file', 'lnum', 'severity', 'message' }
+local severity_map = {
+  ['ERROR'] = vim.diagnostic.severity.ERROR,
+  ['WARNING'] = vim.diagnostic.severity.WARN,
+  ['CHECK'] = vim.diagnostic.severity.INFO,
+}
+
+return {
+  cmd = 'checkpatch.pl',
+  stdin = false,
+  args = {
+    '--strict',
+    '--terse',
+    '--file',
+  },
+  ignore_exitcode = true,
+  parser = require('lint.parser').from_pattern(
+    pattern, groups, severity_map,
+    { ['source'] = 'checkpatch' }
+  ),
+}

--- a/tests/checkpatch_spec.lua
+++ b/tests/checkpatch_spec.lua
@@ -1,0 +1,47 @@
+describe('linter.checkpatch', function()
+  it('can parse the output', function()
+    local parser = require('lint.linters.checkpatch').parser
+    local bufnr = vim.uri_to_bufnr('file:///foo.c')
+    local result = parser([[
+/foo.c:6: CHECK: Please don't use multiple blank lines
+/foo.c:8: WARNING: Missing a blank line after declarations
+/foo.c:10: ERROR: switch and case should be at the same indent
+]], bufnr)
+
+  assert.are.same(3, #result)
+
+  local expected_info = {
+    source = 'checkpatch',
+    message = 'Please don\'t use multiple blank lines',
+    lnum = 5,
+    col = 0,
+    end_lnum = 5,
+    end_col = 0,
+    severity = vim.diagnostic.severity.INFO,
+  }
+  assert.are.same(expected_info, result[1])
+
+  local expected_warning = {
+    source = 'checkpatch',
+    message = 'Missing a blank line after declarations',
+    lnum = 7,
+    col = 0,
+    end_lnum = 7,
+    end_col = 0,
+    severity = vim.diagnostic.severity.WARN,
+  }
+  assert.are.same(expected_warning, result[2])
+
+  local expected_error = {
+    source = 'checkpatch',
+    message = 'switch and case should be at the same indent',
+    lnum = 9,
+    col = 0,
+    end_lnum = 9,
+    end_col = 0,
+    severity = vim.diagnostic.severity.ERROR,
+  }
+  assert.are.same(expected_error, result[3])
+
+  end)
+end)


### PR DESCRIPTION
As described in checkpatch.lua, the user either needs to adjust cmd from its config to provide a full path to checkpatch.pl, or checkpatch.pl should be available in the PATH.