### PR TITLE
Add --no-fix to ruff command line

### DIFF
--- a/lua/lint/linters/ruff.lua
+++ b/lua/lint/linters/ruff.lua
@@ -12,6 +12,7 @@ return {
     '--quiet',
     '--stdin-filename',
     get_file_name,
+    '--no-fix',
     '-',
   },
   ignore_exitcode = true,


### PR DESCRIPTION
I recently encountered a project whose ruff configuration sets the `fix` option.  That's all very well when running from the command line - and `ruff --fix --stdin-filename % -` makes a fine `formatprg` - but it's not what's wanted here.

The result is that the buffer contents are sent through ruff, which fixes them, and reports no errors.

Add `--no-fix` to the command line to solve this.