### PR TITLE
Add Support for PHP's built-in linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ Other dedicated linters that are built-in are:
 | [Nix][nix]                         | `nix`             |
 | [npm-groovy-lint][npm-groovy-lint] | `npm-groovy-lint` |
 | [oelint-adv][oelint-adv]           | `oelint-adv`      |
+| [php][php]                         | `php`             |
 | [phpcs][phpcs]                     | `phpcs`           |
+| [phpmd][phpmd]                     | `phpmd`           |
 | [phpstan][phpstan]                 | `phpstan`         |
 | [proselint][proselint]             | `proselint`       |
 | [psalm][psalm]                     | `psalm`           |
@@ -348,7 +350,9 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [rstcheck]: https://github.com/myint/rstcheck
 [rstlint]: https://github.com/twolfson/restructuredtext-lint
 [ktlint]: https://github.com/pinterest/ktlint
+[php]: https://www.php.net/
 [phpcs]: https://github.com/squizlabs/PHP_CodeSniffer
+[phpmd]: https://phpmd.org/
 [phpstan]: https://phpstan.org/
 [psalm]: https://psalm.dev/
 [lacheck]: https://www.ctan.org/tex-archive/support/lacheck

--- a/lua/lint/linters/php.lua
+++ b/lua/lint/linters/php.lua
@@ -1,0 +1,20 @@
+local efm=''
+efm = efm..'Deprecated:\\ %m\\ %tn\\ Standard\\ input\\ code\\ on\\ line\\ %l' -- nasty hack for %t
+efm = efm..',%tarning:\\ %m\\ in\\ Standard\\ input\\ code\\ on\\ line\\ %l'
+efm = efm..',Parse\\ %trror:\\ %m\\ in\\ Standard\\ input\\ code\\ on\\ line\\ %l'
+efm = efm..',Fatal\\ %trror:\\ %m\\ in\\ Standard\\ input\\ code\\ on\\ line\\ %l'
+
+return {
+  cmd = 'php',
+  stdin = true,
+  args = {
+    -- '-d error_reporting=-1',
+    '-d display_errors=stdout',
+    '-l',
+  },
+  stream = 'stdout',
+  ignore_exitcode = true,
+  parser = require('lint.parser').from_errorformat(efm, {
+    source = 'php'
+  })
+}

--- a/lua/lint/linters/php.lua
+++ b/lua/lint/linters/php.lua
@@ -1,8 +1,9 @@
-local efm=''
-efm = efm..'Deprecated:\\ %m\\ %tn\\ Standard\\ input\\ code\\ on\\ line\\ %l' -- nasty hack for %t
-efm = efm..',%tarning:\\ %m\\ in\\ Standard\\ input\\ code\\ on\\ line\\ %l'
-efm = efm..',Parse\\ %trror:\\ %m\\ in\\ Standard\\ input\\ code\\ on\\ line\\ %l'
-efm = efm..',Fatal\\ %trror:\\ %m\\ in\\ Standard\\ input\\ code\\ on\\ line\\ %l'
+local efm = table.concat({
+  'Deprecated:\\ %m\\ %tn\\ Standard\\ input\\ code\\ on\\ line\\ %l', -- nasty hack for %t
+  '%tarning:\\ %m\\ in\\ Standard\\ input\\ code\\ on\\ line\\ %l',
+  'Parse\\ %trror:\\ %m\\ in\\ Standard\\ input\\ code\\ on\\ line\\ %l',
+  'Fatal\\ %trror:\\ %m\\ in\\ Standard\\ input\\ code\\ on\\ line\\ %l',
+}, ',')
 
 return {
   cmd = 'php',

--- a/tests/php_spec.lua
+++ b/tests/php_spec.lua
@@ -1,0 +1,116 @@
+describe('linter.php', function()
+  it("doesn't error on empty output", function()
+    local parser = require('lint.linters.php').parser
+    parser('')
+    parser('  ')
+  end)
+
+  it("handles the default output when there are no errors or warnings", function()
+    local parser = require('lint.linters.php').parser
+    local result = parser('No syntax errors detected in Standard input code')
+    assert.are.same(0, #result)
+  end)
+
+  it("handles warnings in the output", function()
+    local parser = require('lint.linters.php').parser
+    local result = parser([[
+
+Warning: The use statement with non-compound name 'Foo' has no effect in Standard input code on line 3
+
+
+Warning: The use statement with non-compound name 'Bar' has no effect in Standard input code on line 4
+
+No syntax errors detected in Standard input code
+    ]], vim.api.nvim_get_current_buf())
+    assert.are.same(2, #result)
+
+    local expected = {
+      lnum = 2,
+      end_lnum = 2,
+      col = 0,
+      end_col = 0,
+      message = 'The use statement with non-compound name \'Foo\' has no effect',
+      source = 'php',
+      severity = vim.diagnostic.severity.WARN
+    }
+    assert.are.same(expected, result[1])
+
+    local expected = {
+      lnum = 3,
+      end_lnum = 3,
+      col = 0,
+      end_col = 0,
+      message = 'The use statement with non-compound name \'Bar\' has no effect',
+      source = 'php',
+      severity = vim.diagnostic.severity.WARN
+    }
+    assert.are.same(expected, result[2])
+  end)
+
+  it("handles a parse error in the output", function()
+    local parser = require('lint.linters.php').parser
+    local result = parser([[
+
+Parse error: syntax error, unexpected token "function", expecting "," or ";" in Standard input code on line 9
+
+Errors parsing Standard input code
+    ]], vim.api.nvim_get_current_buf())
+    assert.are.same(1, #result)
+
+    local expected = {
+      lnum = 8,
+      end_lnum = 8,
+      col = 0,
+      end_col = 0,
+      message = 'syntax error, unexpected token "function", expecting "," or ";"',
+      source = 'php',
+      severity = vim.diagnostic.severity.ERROR
+    }
+    assert.are.same(expected, result[1])
+  end)
+
+  it("handles a fatal error in the output", function()
+    local parser = require('lint.linters.php').parser
+    local result = parser([[
+
+Fatal error: Unparenthesized `a ? b : c ? d : e` is not supported. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` in Standard input code on line 3
+
+Errors parsing Standard input code
+    ]], vim.api.nvim_get_current_buf())
+    assert.are.same(1, #result)
+
+    local expected = {
+      lnum = 2,
+      end_lnum = 2,
+      col = 0,
+      end_col = 0,
+      message = 'Unparenthesized `a ? b : c ? d : e` is not supported. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`',
+      source = 'php',
+      severity = vim.diagnostic.severity.ERROR
+    }
+    assert.are.same(expected, result[1])
+  end)
+
+  it("handles a deprecation notices in the output", function()
+    local parser = require('lint.linters.php').parser
+    local result = parser([[
+
+Deprecated: Optional parameter $a declared before required parameter $b is implicitly treated as a required parameter in Standard input code on line 3
+
+No syntax errors detected in Standard input code
+    ]], vim.api.nvim_get_current_buf())
+    assert.are.same(1, #result)
+
+    local expected = {
+      lnum = 2,
+      end_lnum = 2,
+      col = 0,
+      end_col = 0,
+      message = 'Optional parameter $a declared before required parameter $b is implicitly treated as a required parameter',
+      source = 'php',
+      severity = vim.diagnostic.severity.INFO
+    }
+    assert.are.same(expected, result[1])
+  end)
+
+end)

--- a/tests/php_spec.lua
+++ b/tests/php_spec.lua
@@ -35,7 +35,7 @@ No syntax errors detected in Standard input code
     }
     assert.are.same(expected, result[1])
 
-    local expected = {
+    expected = {
       lnum = 3,
       end_lnum = 3,
       col = 0,


### PR DESCRIPTION
This one picks up basic syntax errors using PHP's built-in linter (`php -l`).

It would be good to add this to nvim-lint, since other tools support this:

- [ALE](https://github.com/dense-analysis/ale/blob/master/ale_linters/php/php.vim)
- [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/diagnostics/php.lua)