### PR TITLE
PHPMD: Set diagnostic code to be PHPMD rule name

### DIFF
--- a/lua/lint/linters/phpmd.lua
+++ b/lua/lint/linters/phpmd.lua
@@ -41,6 +41,7 @@ return {
         col = 0,
         end_col = 0,
         message = msg.description,
+        code = msg.rule,
         source = 'phpmd',
         severity = assert(severities[msg.priority], 'missing mapping for severity ' .. msg.priority),
       })

--- a/tests/phpmd_spec.lua
+++ b/tests/phpmd_spec.lua
@@ -81,6 +81,7 @@ describe('linter.phpmd', function()
       col = 0,
       end_col = 0,
       message = 'The class MyClass has an overall complexity of 61 which is very high. The configured complexity threshold is 50.',
+      code = 'ExcessiveClassComplexity',
       source = 'phpmd',
       severity = vim.diagnostic.severity.INFO
     }
@@ -92,6 +93,7 @@ describe('linter.phpmd', function()
       col = 0,
       end_col = 0,
       message = 'The method myMethod() has a Cyclomatic Complexity of 10. The configured cyclomatic complexity threshold is 10.',
+      code = 'CyclomaticComplexity',
       source = 'phpmd',
       severity = vim.diagnostic.severity.INFO,
     }
@@ -103,6 +105,7 @@ describe('linter.phpmd', function()
       col = 0,
       end_col = 0,
       message = 'Avoid excessively long variable names like $thisIsAVeryLongVariableName. Keep variable name length under 20.',
+      code = 'LongVariable',
       source = 'phpmd',
       severity = vim.diagnostic.severity.INFO,
     }


### PR DESCRIPTION
Makes violations easier to fix.

_Without_ this change, you might see this in [Trouble](https://github.com/folke/trouble.nvim):

```
Avoid variables with short names like $id. Configured minimum length is 3. phpmd [36, 1]
```

_With_ this change, you'd see this instead:

```
Avoid variables with short names like $id. Configured minimum length is 3. phpmd (ShortVariable) [36, 1]
```

By way of justification, you might want to add an annotation that looks like this:

```php
/**
 * @SuppressWarnings(PHPMD.LongVariable)
 */
```

Having easy access to PHPMD rule name makes this much easier.