### PR TITLE
staticcheck: don't use stdin

### DIFF
--- a/lua/lint/linters/staticcheck.lua
+++ b/lua/lint/linters/staticcheck.lua
@@ -6,7 +6,7 @@ local severities = {
 
 return {
   cmd = 'staticcheck',
-  stdin = true,
+  stdin = false,
   args = {
     '-f', 'json',
   },


### PR DESCRIPTION
Unfortunately `staticcheck` is not able to process stdin (at least in version 2023.1.3 (v0.4.3)). Therefore the default configuration should use the filename instead.

```
λ cat ./pkg/metrics/metrics.go | staticcheck -f json
{"code":"compile","severity":"error","location":{"file":"","line":0,"column":0},"end":{"file":"","line":0,"column":0},"message":"no Go files in ."}
```

When setting `stdin` to `false` everything seems to work.