### PR TITLE
fix: cspell not work

### DIFF
--- a/lua/lint/linters/cspell.lua
+++ b/lua/lint/linters/cspell.lua
@@ -1,18 +1,38 @@
+local efm = '%f:%l:%c - %m'
 return {
   cmd = 'cspell',
-  stdin = true,
   ignore_exitcode = true,
   args = {
     'lint',
     '--no-color',
     '--no-progress',
     '--no-summary',
-    '--',
-    'stdin'
   },
   stream = 'stdout',
-  parser = require('lint.parser').from_errorformat('/:%l:%c - %m', {
-    source = 'cspell',
-    severity = vim.diagnostic.severity.INFO
-  })
+  parser = function(output)
+    local lines = vim.split(output, '\n')
+    local qflist = vim.fn.getqflist({ efm = efm, lines = lines })
+    local result = {}
+    for _, item in pairs(qflist.items) do
+      if item.valid == 1 then
+        local message = item.text:match('^%s*(.-)%s*$')
+        local word = message:match('%(.*%)')
+        local lnum = math.max(0, item.lnum - 1)
+        local col = math.max(0, item.col - 1)
+        local end_lnum = item.end_lnum > 0 and (item.end_lnum - 1) or lnum
+        local end_col = col + word:len() - 2 or col
+        local diagnostic = {
+          lnum = lnum,
+          col = col,
+          end_lnum = end_lnum,
+          end_col = end_col,
+          message = message,
+          source = 'cspell',
+          severity = vim.diagnostic.severity.INFO
+        }
+        table.insert(result, diagnostic)
+      end
+    end
+    return result
+  end
 }

--- a/tests/cspell_spec.lua
+++ b/tests/cspell_spec.lua
@@ -17,7 +17,7 @@ describe('linter.cspell', function()
       lnum = 258,
       col = 7,
       end_lnum = 258,
-      end_col = 7,
+      end_col = 17,
       severity = vim.diagnostic.severity.INFO,
     }
     assert.are.same(expected_1, result[1])
@@ -28,7 +28,7 @@ describe('linter.cspell', function()
       lnum = 271,
       col = 18,
       end_lnum = 271,
-      end_col = 18,
+      end_col = 26,
       severity = vim.diagnostic.severity.INFO,
     }
     assert.are.same(expected_2, result[2])
@@ -39,7 +39,7 @@ describe('linter.cspell', function()
       lnum = 277,
       col = 18,
       end_lnum = 277,
-      end_col = 18,
+      end_col = 26,
       severity = vim.diagnostic.severity.INFO,
     }
     assert.are.same(expected_3, result[3])
@@ -50,7 +50,7 @@ describe('linter.cspell', function()
       lnum = 320,
       col = 1,
       end_lnum = 320,
-      end_col = 1,
+      end_col = 11,
       severity = vim.diagnostic.severity.INFO,
     }
     assert.are.same(expected_4, result[4])


### PR DESCRIPTION
cspell lint have some issue, it have no diagnostics, and the parse function return wrong `end_col`  value. this PR fix these.