### PR TITLE
adding tfsec lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Other dedicated linters that are built-in are:
 | [vint][21]                         | `vint`            |
 | [vulture][vulture]                 | `vulture`         |
 | [yamllint][yamllint]               | `yamllint`        |
+| [tfsec][tfsec]                     | `tfsec`           |
 
 ## Custom Linters
 
@@ -378,3 +379,4 @@ nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests
 [actionlint]: https://github.com/rhysd/actionlint
 [buf_lint]: https://github.com/bufbuild/buf
 [erb-lint]: https://github.com/shopify/erb-lint
+[tfsec]: https://github.com/aquasecurity/tfsec

--- a/lua/lint/linters/tfsec.lua
+++ b/lua/lint/linters/tfsec.lua
@@ -14,10 +14,10 @@ return {
     if not ok then
       return diagnostics
     end
-    local fname = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t")
+    local fpath = vim.api.nvim_buf_get_name(bufnr)
     for _, result in ipairs(decoded and decoded.results or {}) do
       -- Only show results of the current file in the buffer
-      if result.location.filename == fname then
+      if result.location.filename == fpath then
         local err = {
           source = "tfsec",
           message = string.format("%s %s", result.description, result.impact),

--- a/lua/lint/linters/tfsec.lua
+++ b/lua/lint/linters/tfsec.lua
@@ -10,10 +10,14 @@ return {
   stream = 'stdout',
   parser = function(output, bufnr)
     local diagnostics = {}
-    local _, decoded = pcall(vim.json.decode, output)
-    for _, result in ipairs(decoded.results) do
+    local ok, decoded = pcall(vim.json.decode, output)
+    if not ok then
+      return diagnostics
+    end
+    local fname = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t")
+    for _, result in ipairs(decoded and decoded.results or {}) do
       -- Only show results of the current file in the buffer
-      if result.location.filename == vim.api.nvim_buf_get_name(bufnr) then
+      if result.location.filename == fname then
         local err = {
           source = "tfsec",
           message = string.format("%s %s", result.description, result.impact),

--- a/lua/lint/linters/tfsec.lua
+++ b/lua/lint/linters/tfsec.lua
@@ -1,0 +1,32 @@
+local severity_map = {
+  ["MEDIUM"] = vim.diagnostic.severity.WARN,
+  ["HIGH"] = vim.diagnostic.severity.ERROR
+}
+
+return {
+  cmd = 'tfsec',
+  stdin = true,
+  args = { "-s", "-f", "json" },
+  stream = 'stdout',
+  parser = function(output, bufnr)
+    local diagnostics = {}
+    local _, decoded = pcall(vim.json.decode, output)
+    for _, result in ipairs(decoded.results) do
+      -- Only show results of the current file in the buffer
+      if result.location.filename == vim.api.nvim_buf_get_name(bufnr) then
+        local err = {
+          source = "tfsec",
+          message = string.format("%s %s", result.description, result.impact),
+          col = result.location.start_line,
+          end_col = result.location.end_line,
+          lnum = result.location.start_line - 1,
+          end_lnum = result.location.end_line - 1,
+          code = result.rule_id,
+          severity = severity_map[result.severity],
+        }
+        table.insert(diagnostics, err)
+      end
+    end
+    return diagnostics
+  end
+}

--- a/tests/tfsec_spec.lua
+++ b/tests/tfsec_spec.lua
@@ -23,7 +23,7 @@ describe('linter.tfsec', function()
             "status": 0,
             "resource": "aws_kms_key.key",
             "location": {
-              "filename": "main.tf",
+              "filename": "/main.tf",
               "start_line": 1,
               "end_line": 4
             }

--- a/tests/tfsec_spec.lua
+++ b/tests/tfsec_spec.lua
@@ -2,17 +2,47 @@ describe('linter.tfsec', function()
   it('Parses output sample', function()
     local parser = require('lint.linters.tfsec').parser
     local bufnr = vim.uri_to_bufnr('file:///main.tf')
-    local result = parser(
-      '{"results": [{"rule_id": "AVD-AWS-0065","long_id": "aws-kms-auto-rotate-keys","rule_description": "A KMS key is not configured to auto-rotate.","rule_provider": "aws","rule_service": "kms","impact": "Long life KMS keys increase the attack surface when compromised","resolution": "Configure KMS key to auto rotate","links": ["https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/kms/auto-rotate-keys/","https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key#enable_key_rotation"],"description": "Key does not have rotation enabled.","severity": "MEDIUM","warning": false,"status": 0,"resource": "aws_kms_key.key","location": {"filename": "main.tf","start_line": 1,"end_line": 4}}]}',
-      bufnr)
+    local output = [[
+      {
+        "results": [
+          {
+            "rule_id": "AVD-AWS-0065",
+            "long_id": "aws-kms-auto-rotate-keys",
+            "rule_description": "A KMS key is not configured to auto-rotate.",
+            "rule_provider": "aws",
+            "rule_service": "kms",
+            "impact": "Long life KMS keys increase the attack surface when compromised",
+            "resolution": "Configure KMS key to auto rotate",
+            "links": [
+              "https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/kms/auto-rotate-keys/",
+              "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key#enable_key_rotation"
+            ],
+            "description": "Key does not have rotation enabled.",
+            "severity": "MEDIUM",
+            "warning": false,
+            "status": 0,
+            "resource": "aws_kms_key.key",
+            "location": {
+              "filename": "main.tf",
+              "start_line": 1,
+              "end_line": 4
+            }
+          }
+        ]
+      }
+    ]]
+    local result = parser(output, bufnr)
     local expected = {
-      source = 'tfsec',
-      message = "Key does not have rotation enabled. Long life KMS keys increase the attack surface when compromised",
-      lnum = 1,
-      col = 1,
-      end_lnum = 4,
-      end_col = 4,
-      severity = vim.diagnostic.severity.WARN,
+      {
+        source = 'tfsec',
+        message = "Key does not have rotation enabled. Long life KMS keys increase the attack surface when compromised",
+        lnum = 0,
+        end_lnum = 3,
+        col = 1,
+        end_col = 4,
+        severity = vim.diagnostic.severity.WARN,
+        code = "AVD-AWS-0065",
+      }
     }
     assert.are.same(expected, result)
   end)

--- a/tests/tfsec_spec.lua
+++ b/tests/tfsec_spec.lua
@@ -1,0 +1,19 @@
+describe('linter.tfsec', function()
+  it('Parses output sample', function()
+    local parser = require('lint.linters.tfsec').parser
+    local bufnr = vim.uri_to_bufnr('file:///main.tf')
+    local result = parser(
+      '{"results": [{"rule_id": "AVD-AWS-0065","long_id": "aws-kms-auto-rotate-keys","rule_description": "A KMS key is not configured to auto-rotate.","rule_provider": "aws","rule_service": "kms","impact": "Long life KMS keys increase the attack surface when compromised","resolution": "Configure KMS key to auto rotate","links": ["https://aquasecurity.github.io/tfsec/v1.28.1/checks/aws/kms/auto-rotate-keys/","https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key#enable_key_rotation"],"description": "Key does not have rotation enabled.","severity": "MEDIUM","warning": false,"status": 0,"resource": "aws_kms_key.key","location": {"filename": "main.tf","start_line": 1,"end_line": 4}}]}',
+      bufnr)
+    local expected = {
+      source = 'tfsec',
+      message = "Key does not have rotation enabled. Long life KMS keys increase the attack surface when compromised",
+      lnum = 1,
+      col = 1,
+      end_lnum = 4,
+      end_col = 4,
+      severity = vim.diagnostic.severity.WARN,
+    }
+    assert.are.same(expected, result)
+  end)
+end)


### PR DESCRIPTION
Including tfsec as a linter. Works as intended on my 4-5 manifests.
Only shows the actual lint messages if the filename matches what the linter is pointing out (prevents random messages showing up in non active files)

Tests added but struggled to make them work, would appreciate some guidance there.
Heavily inspired by how null-ls did it.