### PR TITLE
Configure djlint to read from stdin

### DIFF
--- a/lua/lint/linters/djlint.lua
+++ b/lua/lint/linters/djlint.lua
@@ -1,5 +1,5 @@
-local pattern = [[([^:]+):(%d+):(%d+):(%d+): (.*)]]
-local groups = { 'file', 'lnum', 'col', 'code', 'message' }
+local pattern = [[(%d+):(%d+):(%a%d+): (.*)]]
+local groups = { 'lnum', 'col', 'code', 'message' }
 
 local defaults = {
   ['source'] = 'djlint',
@@ -8,10 +8,11 @@ local defaults = {
 
 return {
   cmd = 'djlint',
-  stdin = false,
+  stdin = true,
   args = {
     '--linter-output-format',
-    '{filename}:{line}:{code}: {message}',
+    '{line}:{code}: {message}',
+    '-',
   },
   stream = 'both',
   ignore_exitcode = true,


### PR DESCRIPTION
Thanks to Daniele for the original `djlint` support.

This PR is derived from it, fixes the pattern (as [the linter rules are prefixed by a letter](https://www.djlint.com/docs/linter/#rules) and the capture group should be `(%a%d+)`), and modifies the implementation to read from stdin.

- Change stdin key from false to true.
- Remove filename from pattern, groups, and args.
- Add - to args so djlint knows to read from stdin.
- Fix pattern to capture codes properly.