### PR TITLE
Add `--force-exclude` to Ruff args

### DIFF
--- a/lua/lint/linters/ruff.lua
+++ b/lua/lint/linters/ruff.lua
@@ -9,6 +9,7 @@ return {
   cmd = 'ruff',
   stdin = true,
   args = {
+    '--force-exclude',
     '--quiet',
     '--stdin-filename',
     get_file_name,


### PR DESCRIPTION
Relevant discussion: https://github.com/astral-sh/ruff/discussions/5857#discussioncomment-6583943

Arguments provided to every Ruff invocation by `ruff-lsp`:

https://github.com/astral-sh/ruff-lsp/blob/d642bed6c91fcfdaa29c84555575d069d178146b/ruff_lsp/server.py#L99-L108