### PR TITLE
feat: add buildifier linter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Other dedicated linters that are built-in are:
 | [bandit][bandit]                   | `bandit`          |
 | [bean-check][bean-check]           | `bean_check`      |
 | [buf_lint][buf_lint]               | `buf_lint`        |
+| [buildifier][buildifier]           | `buildifier`      |
 | [cfn-lint][cfn-lint]               | `cfn_lint`        |
 | [cfn_nag][cfn_nag]                 | `cfn_nag`         |
 | [checkpatch.pl][checkpatch]        | `checkpatch`      |
@@ -377,3 +378,4 @@ busted tests/
 [erb-lint]: https://github.com/shopify/erb-lint
 [tfsec]: https://github.com/aquasecurity/tfsec
 [djlint]: https://djlint.com/
+[buildifier]: https://github.com/bazelbuild/buildtools/tree/master/buildifier

--- a/lua/lint/linters/buildifier.lua
+++ b/lua/lint/linters/buildifier.lua
@@ -1,0 +1,104 @@
+-- See the source for the formats
+-- https://github.com/bazelbuild/buildtools/blob/b31f2c13c407575100d4614bcc9a3c60be07cc1c/buildifier/utils/diagnostics.go#L39
+
+local function parse_stdout_json(line)
+  local diagnostics = {}
+
+  local out = vim.json.decode(line)
+  if out.success == true then
+    return diagnostics
+  end
+
+  local f = out.files[1]
+  if not f.warnings then
+    return diagnostics
+  end
+
+  if not f.formatted then
+    table.insert(diagnostics, {
+      lnum = 0,
+      col = 0,
+      severity = vim.diagnostic.severity.HINT,
+      source = 'buildifier',
+      message = 'Please run buildifier to reformat the file contents.',
+      code = 'reformat',
+    })
+  end
+
+  for _, item in ipairs(f.warnings) do
+    local severity = vim.diagnostic.severity.INFO
+    if item.actionable == true then
+      severity = vim.diagnostic.severity.WARN
+    end
+
+    table.insert(diagnostics, {
+      lnum = item.start.line - 1,
+      col = item.start.column - 1,
+      end_lnum = item["end"].line - 1,
+      end_col = item["end"].column - 1,
+      severity = severity,
+      source = 'buildifier',
+      message = item.message .. '\n\n' .. item.url,
+      code = item.category,
+    })
+  end
+
+  return diagnostics
+end
+
+local function parse_stderr_line(line)
+  -- This part parses the buildifier output that usually comes via stderr which
+  -- is not in JSON format yet.
+  local parts = vim.split(line, ":")
+  local lnum, col, message = 0, 0, ""
+
+  if #parts >= 4 then
+    lnum = tonumber(parts[2]) - 1
+    col = tonumber(parts[3]) - 1
+    message = table.concat(parts, ":", 4)
+  elseif #parts == 3 then
+    lnum = tonumber(parts[2]) - 1
+    message = parts[3]
+  end
+
+  if message ~= "" then
+    return {{
+      lnum = lnum,
+      col = col,
+      severity = vim.diagnostic.severity.ERROR,
+      source = 'buildifier',
+      message = message:gsub("^%s+", ""),
+      code = 'syntax',
+    }}
+  end
+
+  return {}
+end
+
+return {
+  cmd = 'buildifier',
+  append_fname = true,
+  args = {
+    "-lint=warn",
+    "-mode=check",
+    "-warnings=all",
+    "-format=json",
+  },
+  stream = "both",
+  parser = function(output)
+    local diagnostics = {}
+    local lines = vim.split(output, '\n')
+    for _, line in ipairs(lines) do
+      if vim.startswith(line, '{') then
+        for _, d in ipairs(parse_stdout_json(line)) do
+          table.insert(diagnostics, d)
+        end
+      else
+        for _, d in ipairs(parse_stderr_line(line)) do
+          table.insert(diagnostics, d)
+        end
+      end
+    end
+    return diagnostics
+  end,
+}

--- a/lua/lint/linters/buildifier.lua
+++ b/lua/lint/linters/buildifier.lua
@@ -2,17 +2,21 @@
 -- https://github.com/bazelbuild/buildtools/blob/b31f2c13c407575100d4614bcc9a3c60be07cc1c/buildifier/utils/diagnostics.go#L39
 
 local function get_cur_file_type(bufnr)
+  -- Logic taken from https://github.com/bazelbuild/buildtools/blob/master/build/lex.go#L125
   bufnr = bufnr or 0
   local fname = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ':t')
+  fname = string.lower(fname)
 
-  if fname == "BUILD" or vim.startswith(fname, "BUILD.") then
-    return "build"
+  if fname == "module.bazel" then
+    return "module"
   elseif vim.endswith(fname, ".bzl") then
     return "bzl"
-  elseif vim.startswith(fname, "WORKSPACE") then
+  elseif vim.endswith(fname, ".sky") then
+    return "default"
+  elseif fname == "build" or vim.startswith(fname, "build.") or vim.endswith(fname, ".build") then
+    return "build"
+  elseif fname == "workspace" or vim.startswith(fname, "workspace.") or vim.endswith(fname, ".workspace") then
     return "workspace"
-  elseif vim.startswith(fname, "MODULE") or vim.startswith(fname, "REPO") then
-    return "module"
   else
     return "default"
   end


### PR DESCRIPTION
Supports both, parsing the warnings from the stdout and the syntax error messages from the stderr. This has been tested with the latest `buildifier` version installed via williamboman/mason.nvim.
