### PR TITLE
Run cspell linter installed by npm via cmd.exe on Windows

### DIFF
--- a/lua/lint/linters/cspell.lua
+++ b/lua/lint/linters/cspell.lua
@@ -1,5 +1,5 @@
 local efm = '%f:%l:%c - %m'
-return {
+local opts = {
   cmd = 'cspell',
   ignore_exitcode = true,
   args = {
@@ -36,3 +36,5 @@ return {
     return result
   end
 }
+
+return require("lint.util").inject_cmd_exe(opts)


### PR DESCRIPTION
inspired by [Fix eslint ](https://github.com/mfussenegger/nvim-lint/pull/314) 0b99416, change cspell lint config