### PR TITLE
Allow Janet linter to use stdin

### DIFF
--- a/lua/lint/linters/janet.lua
+++ b/lua/lint/linters/janet.lua
@@ -4,7 +4,7 @@ local groups = { 'lnum', 'col', 'message' }
 
 return {
   cmd = 'janet',
-  stdin = false,
+  stdin = true,
   args = {
     '-k',
   },


### PR DESCRIPTION
When run with `janet -k`, input will be read from stdin. This change allows this linter to be used with events like `TextChanged` and `InsertLeave`.