### PR TITLE
fix: shellcheck error when making quick successive changes

### DIFF
--- a/lua/lint/linters/shellcheck.lua
+++ b/lua/lint/linters/shellcheck.lua
@@ -14,6 +14,7 @@ return {
   },
   ignore_exitcode = true,
   parser = function(output)
+    if output == "" then return {} end
     local decoded = vim.json.decode(output)
     local diagnostics = {}
     for _, item in ipairs(decoded or {}) do


### PR DESCRIPTION
Quick successive changes result in this error:

```
  Error  20:06:23 msg_show.lua_error Error executing vim.schedule lua callback: ...hare/nvim/lazy/nvim-lint/lua/lint/linters/shellcheck.lua:17: Expected value but found T_END at character 1
stack traceback:
	[C]: in function 'decode'
	...hare/nvim/lazy/nvim-lint/lua/lint/linters/shellcheck.lua:17: in function 'parse'
	...ser/.local/share/nvim/lazy/nvim-lint/lua/lint/parser.lua:123: in function <...ser/.local/share/nvim/lazy/nvim-lint/lua/lint/parser.lua:119>
```

checking whether there is actual output fixes that.