### PR TITLE
Handle empty output in `pylint` to avoid JSON decode errors

### DIFF
--- a/lua/lint/linters/pylint.lua
+++ b/lua/lint/linters/pylint.lua
@@ -15,6 +15,7 @@ return {
   },
   ignore_exitcode = true,
   parser = function(output, bufnr)
+    if output == "" then return {} end
     local diagnostics = {}
     local buffer_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":~:.")
 


### PR DESCRIPTION
same issue as in #350, only for `pylint`