### PR TITLE
Add linter for rpmspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Other dedicated linters that are built-in are:
 | [robocop][robocop]                 | `robocop`         |
 | [rstcheck][rstcheck]               | `rstcheck`        |
 | [rstlint][rstlint]                 | `rstlint`         |
+| [RPM][rpm]                         | `rpmspec`         |
 | [Ruby][ruby]                       | `ruby`            |
 | [RuboCop][rubocop]                 | `rubocop`         |
 | [Ruff][ruff]                       | `ruff`            |
@@ -389,3 +390,4 @@ busted tests/
 [perlimports]: https://github.com/perl-ide/App-perlimports
 [perlcritic]: https://github.com/Perl-Critic/Perl-Critic
 [gdlint]: https://github.com/Scony/godot-gdscript-toolkit
+[rpm]: https://rpm.org

--- a/lua/lint/linters/rpmspec.lua
+++ b/lua/lint/linters/rpmspec.lua
@@ -1,0 +1,39 @@
+-- This is a linter for https://rpm.org/
+local parsers = {
+  -- errors
+  require('lint.parser').from_pattern(
+    [[(%w+): line (%d+): (.*)]],
+    { 'severity', 'lnum', 'message' },
+    nil,
+    { ['severity'] = vim.diagnostic.severity.ERROR, ['source'] = 'rpmspec' }
+  ),
+
+  -- warnings
+  require('lint.parser').from_pattern(
+    [[(%w+): (.*) on line (%d+):]],
+    { 'severity', 'message', 'lnum' },
+    nil,
+    { ['severity'] = vim.diagnostic.severity.WARNING, ['source'] = 'rpmspec' }
+  ),
+}
+
+-- Usage: rpmspec -P <file>
+return {
+  cmd = 'rpmspec',
+  stdin = false,
+  append_fname = true,
+  args = { '-P' },
+  stream = 'stderr',
+  ignore_exitcode = true,
+  parser = function(output, bufnr)
+    local diagnostics = {}
+
+    for _, parser in ipairs(parsers) do
+      local result = parser(output, bufnr)
+
+      vim.list_extend(diagnostics, result)
+    end
+
+    return diagnostics
+  end,
+}

--- a/lua/lint/linters/rpmspec.lua
+++ b/lua/lint/linters/rpmspec.lua
@@ -5,7 +5,10 @@ local parsers = {
     [[(%w+): line (%d+): (.*)]],
     { 'severity', 'lnum', 'message' },
     nil,
-    { ['severity'] = vim.diagnostic.severity.ERROR, ['source'] = 'rpmspec' }
+    {
+      severity = vim.diagnostic.severity.ERROR,
+      source = 'rpmspec'
+    }
   ),
 
   -- warnings
@@ -13,7 +16,10 @@ local parsers = {
     [[(%w+): (.*) on line (%d+):]],
     { 'severity', 'message', 'lnum' },
     nil,
-    { ['severity'] = vim.diagnostic.severity.WARNING, ['source'] = 'rpmspec' }
+    {
+      severity = vim.diagnostic.severity.WARN,
+      source = 'rpmspec'
+    }
   ),
 }
 
@@ -27,13 +33,10 @@ return {
   ignore_exitcode = true,
   parser = function(output, bufnr)
     local diagnostics = {}
-
     for _, parser in ipairs(parsers) do
       local result = parser(output, bufnr)
-
       vim.list_extend(diagnostics, result)
     end
-
     return diagnostics
   end,
 }

--- a/tests/rpmspec_spec.lua
+++ b/tests/rpmspec_spec.lua
@@ -7,31 +7,27 @@ warning: Macro expanded in comment on line 1: %{?fedora}
 error: line 2: Unknown tag: %if
 ]]
     local result = parser(output, bufnr)
-
     assert.are.same(2, #result)
 
     local expected_warning_1 = {
       col = 0,
       end_col = 0,
-      end_lnum = 1,
-      lnum = 1,
+      end_lnum = 0,
+      lnum = 0,
       message = 'Macro expanded in comment',
-      severity = 2,
+      severity = vim.diagnostic.severity.WARN,
       source = 'rpmspec',
     }
-
-    assert.are.same(expected_warning_1, result[1])
-
     local expected_error_1 = {
       col = 0,
       end_col = 0,
-      end_lnum = 2,
-      lnum = 2,
+      end_lnum = 1,
+      lnum = 1,
       message = 'Unknown tag: %if',
-      severity = 1,
+      severity = vim.diagnostic.severity.ERROR,
       source = 'rpmspec',
     }
-
-    assert.are.same(expected_error_1, result[2])
+    assert.are.same(expected_error_1, result[1])
+    assert.are.same(expected_warning_1, result[2])
   end)
 end)

--- a/tests/rpmspec_spec.lua
+++ b/tests/rpmspec_spec.lua
@@ -1,0 +1,37 @@
+describe('linter.rpmspec', function()
+  it('can parse the output', function()
+    local parser = require('lint.linters.rpmspec').parser
+    local bufnr = vim.uri_to_bufnr('file:///foo.spec')
+    local output = [[
+warning: Macro expanded in comment on line 1: %{?fedora}
+error: line 2: Unknown tag: %if
+]]
+    local result = parser(output, bufnr)
+
+    assert.are.same(2, #result)
+
+    local expected_warning_1 = {
+      col = 0,
+      end_col = 0,
+      end_lnum = 1,
+      lnum = 1,
+      message = 'Macro expanded in comment',
+      severity = 2,
+      source = 'rpmspec',
+    }
+
+    assert.are.same(expected_warning_1, result[1])
+
+    local expected_error_1 = {
+      col = 0,
+      end_col = 0,
+      end_lnum = 2,
+      lnum = 2,
+      message = 'Unknown tag: %if',
+      severity = 1,
+      source = 'rpmspec',
+    }
+
+    assert.are.same(expected_error_1, result[2])
+  end)
+end)


### PR DESCRIPTION
This adds a linter for RPM spec files.

I miss a simple `make test` to quickly run the tests ...