### PR TITLE
Don't call parse on empty outputs

### DIFF
--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -127,7 +127,7 @@ function M.accumulate_chunks(parse)
       vim.schedule(function()
         local output = table.concat(chunks)
         local diagnostics
-        if vim.api.nvim_buf_is_valid(bufnr) then
+        if vim.api.nvim_buf_is_valid(bufnr) and output ~= "" then
           diagnostics = parse(output, bufnr, linter_cwd)
         else
           diagnostics = {}


### PR DESCRIPTION
More general approach to https://github.com/mfussenegger/nvim-lint/pull/365
Instead of fixing each linter one by one, just don't call them if there
is not output.
