### PR TITLE
feat: set code for PHPCS violations

### DIFF
--- a/lua/lint/linters/phpcs.lua
+++ b/lua/lint/linters/phpcs.lua
@@ -33,6 +33,7 @@ return {
         col = msg.column - 1,
         end_col = msg.column - 1,
         message = msg.message,
+        code = msg.source,
         source = 'phpcs',
         severity = assert(severities[msg.type], 'missing mapping for severity ' .. msg.type),
       })

--- a/tests/phpcs_spec.lua
+++ b/tests/phpcs_spec.lua
@@ -80,6 +80,7 @@ describe('linter.phpcs', function()
       col = 0,
       end_col = 0,
       message = 'Missing file doc comment',
+      code = 'PEAR.Commenting.FileComment.Missing',
       source = 'phpcs',
       severity = vim.diagnostic.severity.ERROR
     }
@@ -91,6 +92,7 @@ describe('linter.phpcs', function()
       col = 4,
       end_col = 4,
       message = 'Inline control structures are discouraged',
+      code = 'Generic.ControlStructures.InlineControlStructure.Discouraged',
       source = 'phpcs',
       severity = vim.diagnostic.severity.WARN,
     }


### PR DESCRIPTION
This change includes the source of PHP_CodeSniffer errors/warnings in diagnostic messages.

This means that instead of seeing a diagnostic message like this:

```
Line indented incorrectly; expected 4 spaces, found 5 phpcs [14, 6]
```

... you'll instead see one like this:

```
Line indented incorrectly; expected 4 spaces, found 5 phpcs (Generic.WhiteSpace.ScopeIndent.IncorrectExact) [14, 6]
```

This makes it much easier to disable/enable specific sniffs with a comment like this:

```
// phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact
```

See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file for more info.