### PR TITLE
eslint: use stdin instead of filename

### DIFF
--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -15,8 +15,12 @@ return require('lint.util').inject_cmd_exe({
     end
     return 'eslint'
   end,
-  args = {},
-  stdin = false,
+  args = {
+    '--stdin',
+    '--stdin-filename',
+    function() return vim.api.nvim_buf_get_name(0) end,
+  },
+  stdin = true,
   stream = 'stdout',
   ignore_exitcode = true,
   parser = require('lint.parser').from_pattern(pattern, groups, severity_map, { ['source'] = 'eslint' }),


### PR DESCRIPTION
tested and this works without issue.

this is much better than using the filename, because with this it's possible to lint an unsaved file too.