### PR TITLE
languagetool: Fix parsing error when output contains 'Err:...'

### DIFF
--- a/lua/lint/linters/languagetool.lua
+++ b/lua/lint/linters/languagetool.lua
@@ -19,7 +19,7 @@ return {
   parser = function(output, bufnr)
     local err, json = parse_err_json(output)
     if err then
-      vim.notify(err, vim.log.levels.INFO)
+      vim.notify_once(err, vim.log.levels.INFO)
     end
     local decoded = vim.json.decode(json)
     local diagnostics = {}

--- a/lua/lint/linters/languagetool.lua
+++ b/lua/lint/linters/languagetool.lua
@@ -1,9 +1,27 @@
+-- LanguageTool might give output like "Err: 'yada yada'\n{ ... json here ... }'
+local function parse_err_json(str)
+    local json_start = str:find('{', 1, true)
+    local err = nil
+    local json = str
+
+    if json_start and json_start > 1 then
+        err = str:sub(1, json_start - 1):gsub("^%s*(.-)%s*$", "%1") -- trim spaces
+        json = str:sub(json_start)
+    end
+
+    return err, json
+end
+
 return {
   cmd = 'languagetool',
   args = {'--autoDetect', '--json'},
   stream = 'stdout',
   parser = function(output, bufnr)
-    local decoded = vim.json.decode(output)
+    local err, json = parse_err_json(output)
+    if err then
+      vim.notify(err, vim.log.levels.INFO)
+    end
+    local decoded = vim.json.decode(json)
     local diagnostics = {}
     local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
     local content = table.concat(lines, '\n')


### PR DESCRIPTION
This PR fixes a parsing error when using LanguageTool (`languagetool`) linter for situations where the output JSON is prefixed with an error string.

Previously it would fail the linting, whereas now it parses the JSON correctly.

The warnings are displayed using `vim.notify_once` which annoyingly requires a confirmation. I didn't find any other way to log this. Looked for some logging mechanism in the plugin, but failed to find it if it exists. Saw that the PHP linter used the same tactic (albeit for an error-and-bail rather than a notify-and-continue situation).

The message looks like this:

```
WARN: no common words file defined for Japanese - this language might not be correctly auto-detected
WARN: no common words file defined for Khmer - this language might not be correctly auto-detected
Press ENTER or type command to continue
```

In my particular case I had some warnings only, so a viable option for just me would have been to just ignore the errors. That doesn't feel like a safe option though, since other might have actual errors that could help them debug why it fails.

It would be nice to have access to the `opts` in the parser function, since that would allow users to choose opt out of the message altogether depending on individual use cases.

Another option I tried was to show the Errors as a lint warning on line 1, but that was persistently annoying instead of just annoying once :)

## Test plan

Ran the plugin on a file with LSP enabled and verified that I got linting for spelling issues in the file, and that I got the error message displayed the expected information, and only once.