### PR TITLE
Add logging to nvim-lint

### DIFF
--- a/lua/lint/logger.lua
+++ b/lua/lint/logger.lua
@@ -1,0 +1,77 @@
+local M = {}
+
+M.log_levels = {
+  error = 1,
+  warning = 2,
+  info = 3,
+  debug = 4,
+}
+
+local log_level = M.log_levels.warning
+
+local function write_to_file(message)
+  local log_path = vim.fn.stdpath('state') .. '/nvim-lint.log'
+  local log_file = io.open(log_path, 'a+')
+  if not log_file then
+    vim.api.nvim_out_write('[nvim-lint] failed to open log file\n')
+    return
+  end
+  log_file:write(message .. '\n')
+  log_file:close()
+end
+
+function M.set_log_level(level)
+  log_level = M.log_levels[level]
+end
+
+local function log(level_name, level, prefix, format, ...)
+  if log_level >= level then
+    local timestamp = os.date('%Y-%m-%d %H:%M:%S')
+    local message = string.format('[%s][%s][%s] ' .. format, timestamp, level_name, prefix, ...)
+    write_to_file(message)
+  end
+end
+
+function M.new(prefix)
+  return {
+    assert = function(condition, format, ...)
+      local arguments = { ... }
+      if not condition then
+        log('ASSERT', M.log_levels.error, prefix, format or '', ...)
+      end
+      return assert(condition, arguments[1])
+    end,
+    error = function(format, ...)
+      local arguments = { ... }
+      log('ERROR', M.log_levels.error, prefix, format, ...)
+      error(arguments[1])
+    end,
+    warning = function(format, ...)
+      log('WARNING', M.log_levels.warning, prefix, format, ...)
+    end,
+    info = function(format, ...)
+      log('INFO', M.log_levels.info, prefix, format, ...)
+    end,
+    debug = function(format, ...)
+      log('DEBUG', M.log_levels.debug, prefix, format, ...)
+    end,
+    format_diagnostic = function(diagnostic)
+      return string.format(
+        'lnum=%d col=%d end_lnum=%d end_col=%d severity=%s message=%s code=%s',
+        diagnostic.lnum,
+        diagnostic.col,
+        diagnostic.end_lnum,
+        diagnostic.end_col,
+        diagnostic.severity,
+        diagnostic.message,
+        diagnostic.code
+      )
+    end,
+  }
+end
+
+function M.open()
+  vim.cmd('e ' .. vim.fn.stdpath('state') .. '/nvim-lint.log')
+end
+
+return M


### PR DESCRIPTION
While working on a custom linter, I found myself in dire need of some logs. So I've gone ahead and added a scrappy logger module to `nvim-lint`.

It's very useful!

## Usage

### While working on a custom linter

```lua
local lint = require("lint")
local parser = require("lint.parser")

require("lint.logger").set_log_level("debug") -- Or "info", "warning", "error"

lint.linters_by_ft.python = { "my_linter" }
lint.linters.my_linter = {
  -- Stuff
}
```

Read the output: `:lua require("lint.logger").open()`.

It will likely open `~/.local/state/nvim/nvim-lint.log`.

### While working on `nvim-lint`

Instantiate a new logger for a module or whatever namespace you need:

```lua
local log = require("lint.logger").new("parser")
```

Note that this may also be useful for custom linters:

```lua
local log = require("lint.logger").new("my_linter")
```

Use `log.{warning,info,debug}` just like `string.format`:

```lua
log.info("Registered from_pattern parser, source=%s", defaults.source)
```

Methods `log.error` and `log.assert` are special: they call `error` and `assert` respectively under the hood, and also log an error.

```lua
local message = log.assert(captures.message, "diagnostic requires a message")
```

## Example output

Here is an example `debug`-level output I see now when trying to work on my custom linter:

```
[2023-10-10 00:00:28][INFO][parser] Registered from_pattern parser, source=mypy
[2023-10-10 00:00:37][INFO][parser] Parsing 11 lines of output
[2023-10-10 00:00:37][DEBUG][parser] [line]: ++ mktemp
[2023-10-10 00:00:37][DEBUG][parser] [result]: no matches
[2023-10-10 00:00:37][DEBUG][parser] [line]: + paths_txt=/tmp/nix-shell.LteQqZ/tmp.rB03Rzvvhu
[2023-10-10 00:00:37][DEBUG][parser] [result]: no matches
[2023-10-10 00:00:37][DEBUG][parser] [line]: + for path in "$@"
[2023-10-10 00:00:37][DEBUG][parser] [result]: no matches
[2023-10-10 00:00:37][DEBUG][parser] [line]: + echo /home/fausto/Development/memfault/tasks/dev.py
[2023-10-10 00:00:37][DEBUG][parser] [result]: no matches
[2023-10-10 00:00:37][DEBUG][parser] [line]: + inv test.mypy --daemon=check --paths-txt /tmp/nix-shell.LteQqZ/tmp.rB03Rzvvhu
[2023-10-10 00:00:37][DEBUG][parser] [result]: no matches
[2023-10-10 00:00:37][DEBUG][parser] [line]: 2023-10-10 00:00:37,256 | memfault.dmypy=check (options: 'check,run,None')
[2023-10-10 00:00:37][DEBUG][parser] [result]: no matches
[2023-10-10 00:00:37][DEBUG][parser] [line]: 2023-10-10 00:00:37,256 | In 'check' mode a daemon must have been started via 'inv mypy.daemon'.
[2023-10-10 00:00:37][DEBUG][parser] [result]: no matches
[2023-10-10 00:00:37][DEBUG][parser] [line]: [FATAL] tasks/__init__.py: error: Duplicate module named "tasks" (also at "tasks/__init__.py")
[2023-10-10 00:00:37][DEBUG][parser] [result]: no matches
[2023-10-10 00:00:37][DEBUG][parser] [line]: [FATAL] tasks/__init__.py: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules for more info
[2023-10-10 00:00:37][DEBUG][parser] [result]: no matches
[2023-10-10 00:00:37][DEBUG][parser] [line]: [FATAL] tasks/__init__.py: note: Common resolutions include: a) using `--exclude` to avoid checking one of them, b) adding `__init__.py` somewhere, c) using `--explicit-package-bases` or adjusting MYPYPATH
[2023-10-10 00:00:37][DEBUG][parser] [result]: no matches
[2023-10-10 00:00:37][DEBUG][parser] [line]: Some mypy checks failed.
[2023-10-10 00:00:37][DEBUG][parser] [result]: no matches
```

## Merging this PR

This is a bit of a nosy PR. I don't know if you want this @mfussenegger. It was useful to me so here it is. You may also have implemented this in a completely different way.

I put this PR in draft mode for the following reasons:

- I will probably break some tests, and I haven't tried to run them yet
- My editor's formatter changed the formatting a bit, I might need to fix that
- I would like to keep the types and comments better, it seems like the built-ins like `assert` and `error` offer some OK type inference that I may need to imitate in my logging wrappers
- The API is open for discussion

Anyway, have a nice day!