### PR TITLE
Use stdin with jsonlint

### DIFF
--- a/lua/lint/linters/jsonlint.lua
+++ b/lua/lint/linters/jsonlint.lua
@@ -1,10 +1,15 @@
+local pattern = "line (%d+), col (%d+), (.*)"
+local groups = { "lnum", "col", "message" }
+local severities = nil -- none provided
+
 return {
   cmd = 'jsonlint',
   stream = 'stderr',
   args = { '--compact' },
+  stdin = true,
   ignore_exitcode = true,
-  parser = require('lint.parser').from_errorformat("%f:\\ line\\ %l\\,\\ col\\ %c\\, %m", {
+  parser = require('lint.parser').from_pattern(pattern, groups, severities, {
     source = 'jsonlint',
     severity = vim.diagnostic.severity.ERROR,
-  })
+  }),
 }


### PR DESCRIPTION
Updated jsonlint parser uses stdin. Now linter updates without writing to file.