### PR TITLE
fix: support end col for eslint

### DIFF
--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -6,10 +6,10 @@ local severities = {
 
 return require('lint.util').inject_cmd_exe({
   cmd = function()
-    local local_eslintd = vim.fn.fnamemodify('./node_modules/.bin/eslint', ':p')
-    local stat = vim.loop.fs_stat(local_eslintd)
+    local local_eslint = vim.fn.fnamemodify('./node_modules/.bin/eslint', ':p')
+    local stat = vim.loop.fs_stat(local_eslint)
     if stat then
-      return local_eslintd
+      return local_eslint
     end
     return 'eslint'
   end,

--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -24,11 +24,11 @@ return require('lint.util').inject_cmd_exe({
   stream = 'stdout',
   ignore_exitcode = true,
   parser = function(output)
-    local json = vim.json.decode(output) or {}
+    local success, decodedData = pcall(vim.json.decode, output)
     local diagnostics = {}
 
-    for _, file in ipairs(json or {}) do
-      for _, diagnostic in ipairs(file.messages or {}) do
+    if success and decodedData ~= nil then
+      for _, diagnostic in ipairs(decodedData.messages or {}) do
         table.insert(diagnostics, {
           source = "eslint",
           lnum = diagnostic.line - 1,

--- a/lua/lint/linters/eslint_d.lua
+++ b/lua/lint/linters/eslint_d.lua
@@ -24,11 +24,11 @@ return require('lint.util').inject_cmd_exe({
   stream = 'stdout',
   ignore_exitcode = true,
   parser = function(output)
-    local json = vim.json.decode(output) or {}
+    local success, decodedData = pcall(vim.json.decode, output)
     local diagnostics = {}
 
-    for _, file in ipairs(json or {}) do
-      for _, diagnostic in ipairs(file.messages or {}) do
+    if success and decodedData ~= nil then
+      for _, diagnostic in ipairs(decodedData.messages or {}) do
         table.insert(diagnostics, {
           source = "eslint_d",
           lnum = diagnostic.line - 1,

--- a/lua/lint/linters/eslint_d.lua
+++ b/lua/lint/linters/eslint_d.lua
@@ -1,9 +1,7 @@
-local pattern = [[%s*(%d+):(%d+)%s+(%w+)%s+(.+%S)%s+(%S+)]]
-local groups = { 'lnum', 'col', 'severity', 'message', 'code' }
-local severity_map = {
-  ['error'] = vim.diagnostic.severity.ERROR,
-  ['warn'] = vim.diagnostic.severity.WARN,
-  ['warning'] = vim.diagnostic.severity.WARN,
+local severities = {
+  nil,
+  vim.diagnostic.severity.ERROR,
+  vim.diagnostic.severity.WARN,
 }
 
 return require('lint.util').inject_cmd_exe({
@@ -16,6 +14,8 @@ return require('lint.util').inject_cmd_exe({
     return 'eslint_d'
   end,
   args = {
+    '--format',
+    'json',
     '--stdin',
     '--stdin-filename',
     function() return vim.api.nvim_buf_get_name(0) end,
@@ -23,5 +23,25 @@ return require('lint.util').inject_cmd_exe({
   stdin = true,
   stream = 'stdout',
   ignore_exitcode = true,
-  parser = require('lint.parser').from_pattern(pattern, groups, severity_map, { ['source'] = 'eslint_d' }),
+  parser = function(output)
+    local json = vim.json.decode(output) or {}
+    local diagnostics = {}
+
+    for _, file in ipairs(json or {}) do
+      for _, diagnostic in ipairs(file.messages or {}) do
+        table.insert(diagnostics, {
+          source = "eslint_d",
+          lnum = diagnostic.line - 1,
+          col = diagnostic.column - 1,
+          end_lnum = diagnostic.endLine - 1,
+          end_col = diagnostic.endColumn - 1,
+          severity = severities[diagnostic.severity],
+          message = diagnostic.message,
+          code = diagnostic.ruleId
+        })
+      end
+    end
+
+    return diagnostics
+  end
 })

--- a/tests/eslint_d_spec.lua
+++ b/tests/eslint_d_spec.lua
@@ -9,32 +9,31 @@ describe("linter.eslint_d", function()
     local parser = require("lint.linters.eslint_d").parser
 
     local result = parser([[
-        {
-          messages = {
-            {
-              column = 10,
-              endColumn = 18,
-              endLine = 1,
-              line = 1,
-              message = "'testFunc' is defined but never used",
-              ruleId = "no-unused-vars",
-              severity = 2
-            },
-            {
-              column = 16,
-              endColumn = 22,
-              endLine = 4,
-              line = 4,
-              message =
-              "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain  no-dupe-else-if",
-              ruleId = "no-dupe-else-if",
-              severity = 2
-            }
-          },
-        }
-    ]], vim.api.nvim_get_current_buf()
-    )
+{
+  "messages": [
+    {
+      "column": 10,
+      "endColumn": 18,
+      "endLine": 1,
+      "line": 1,
+      "message": "'testFunc' is defined but never used",
+      "ruleId": "no-unused-vars",
+      "severity": 2
+    },
+    {
+      "column": 16,
+      "endColumn": 22,
+      "endLine": 4,
+      "line": 4,
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain",
+      "ruleId": "no-dupe-else-if",
+      "severity": 2
+    }
+  ]
+}]])
+
     assert.are.same(2, #result)
+
     local expected_1 = {
       code = "no-unused-vars",
       col = 9,
@@ -44,11 +43,6 @@ describe("linter.eslint_d", function()
       message = "'testFunc' is defined but never used",
       severity = 1,
       source = "eslint_d",
-      user_data = {
-        lsp = {
-          code = "no-unused-vars",
-        },
-      },
     }
     assert.are.same(expected_1, result[1])
 
@@ -62,11 +56,6 @@ describe("linter.eslint_d", function()
       "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain",
       severity = 1,
       source = "eslint_d",
-      user_data = {
-        lsp = {
-          code = "no-dupe-else-if",
-        },
-      },
     }
     assert.are.same(expected_2, result[2])
   end)

--- a/tests/eslint_d_spec.lua
+++ b/tests/eslint_d_spec.lua
@@ -7,21 +7,38 @@ describe("linter.eslint_d", function()
 
   it("can parse output", function()
     local parser = require("lint.linters.eslint_d").parser
-    local result = parser(
-      [[
-/directory/file.js
-  1:10  error  'testFunc' is defined but never used                                                                                   no-unused-vars
-  4:16  error  This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain  no-dupe-else-if
 
-✖ 2 problems (2 errors, 0 warnings)
-    ]],
-      vim.api.nvim_get_current_buf()
+    local result = parser([[
+        {
+          messages = {
+            {
+              column = 10,
+              endColumn = 18,
+              endLine = 1,
+              line = 1,
+              message = "'testFunc' is defined but never used",
+              ruleId = "no-unused-vars",
+              severity = 2
+            },
+            {
+              column = 16,
+              endColumn = 22,
+              endLine = 4,
+              line = 4,
+              message =
+              "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain  no-dupe-else-if",
+              ruleId = "no-dupe-else-if",
+              severity = 2
+            }
+          },
+        }
+    ]], vim.api.nvim_get_current_buf()
     )
     assert.are.same(2, #result)
     local expected_1 = {
       code = "no-unused-vars",
       col = 9,
-      end_col = 9,
+      end_col = 17,
       end_lnum = 0,
       lnum = 0,
       message = "'testFunc' is defined but never used",
@@ -38,10 +55,11 @@ describe("linter.eslint_d", function()
     local expected_2 = {
       code = "no-dupe-else-if",
       col = 15,
-      end_col = 15,
+      end_col = 21,
       end_lnum = 3,
       lnum = 3,
-      message = "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain",
+      message =
+      "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain",
       severity = 1,
       source = "eslint_d",
       user_data = {


### PR DESCRIPTION
This PR aims to add end_col support for the `eslint` and `eslint_d` linters. 

See https://github.com/mfussenegger/nvim-lint/issues/394 for background.