### PR TITLE
fix: ESLint linter expects different output

### DIFF
--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -26,22 +26,24 @@ return require('lint.util').inject_cmd_exe({
     local success, data = pcall(vim.json.decode, output)
     local diagnostics = {}
 
-    for _, item in ipairs(data) do
-      local current_file = vim.api.nvim_buf_get_name(buffer)
-      local linted_file = item.filePath
-
-      if current_file == linted_file then
-        for _, diagnostic in ipairs(item.messages or {}) do
-          table.insert(diagnostics, {
-            source = "eslint",
-            lnum = diagnostic.line - 1,
-            col = diagnostic.column - 1,
-            end_lnum = diagnostic.endLine - 1,
-            end_col = diagnostic.endColumn - 1,
-            severity = severities[diagnostic.severity],
-            message = diagnostic.message,
-            code = diagnostic.ruleId
-          })
+    if success and data ~= nil then
+      for _, item in ipairs(data) do
+        local current_file = vim.api.nvim_buf_get_name(buffer)
+        local linted_file = item.filePath
+  
+        if current_file == linted_file then
+          for _, diagnostic in ipairs(item.messages or {}) do
+            table.insert(diagnostics, {
+              source = "eslint",
+              lnum = diagnostic.line - 1,
+              col = diagnostic.column - 1,
+              end_lnum = diagnostic.endLine - 1,
+              end_col = diagnostic.endColumn - 1,
+              severity = severities[diagnostic.severity],
+              message = diagnostic.message,
+              code = diagnostic.ruleId
+            })
+          end
         end
       end
     end


### PR DESCRIPTION
This PR fixes ESLint linter parsing. Tested on ESLint `v8.42.0`.

The expected format is:
```
[
  {
    "filePath": "<full_file_path>",
    "messages": [
      {
        "ruleId": "simple-import-sort/imports",
        "severity": 1,
        "message": "Run autofix to sort these imports!",
        "line": 1,
        "column": 1,
        "nodeType": null,
        "messageId": "sort",
        "endLine": 14,
        "endColumn": 45,
        "fix": {
          "range": [0, 456],
          "text": "<... fix ...>"
        }
      }
    ],
    "suppressedMessages": [],
    "errorCount": 0,
    "fatalErrorCount": 0,
    "warningCount": 1,
    "fixableErrorCount": 0,
    "fixableWarningCount": 1,
    "source": "<... original ...>",
    "usedDeprecatedRules": []
  }
]
```