### PR TITLE
Fixes race causing previous processes to not be cleaned up

### DIFF
--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -218,9 +218,12 @@ function M.lint(linter, opts)
   handle, pid_or_err = uv.spawn(cmd, linter_opts, function(code)
     if handle and not handle:is_closing() then
       local procs = (running_procs_by_buf[bufnr] or {})
-      procs[linter.name] = nil
-      if not next(procs) then
-        running_procs_by_buf[bufnr] = nil
+      -- Only cleanup if there has not been another procs in between
+      if handle == procs[linter.name] then
+        procs[linter.name] = nil
+        if not next(procs) then
+          running_procs_by_buf[bufnr] = nil
+        end
       end
       handle:close()
     end


### PR DESCRIPTION
There can be a race between the `on_exit` callback of `uv.spawn` and `try_lint` setting `procs[linter.name]` meaning that long running processes may not be cleaned up properly as described in #357.

This PR adds a check that ensures that we only cleanup `running_procs_by_buf` when the handle that triggered the callback is same that is in `procs[linter.name]`.

This technically doesn't stops the callback and `try_lint` racing, it just ensure the callback doesn't remove handles it shouldn't. When the last process in a chain finishes and find it's handle in the data structure then it cleans up.

I have tested this PR using a linter like so, that enabled me to observe long running processes and `:w` several time in sequence to observe the bug and its fix.
```
  require('lint').linters.longsleep = {
    cmd = 'bash',
    stdin = false,
    append_fname = false,
    args = {"-c", "sleep 100"},
    stream = "stdout",
    ignore_exitcode = true,
    parser = function(output, bufNo) return {} end
  }
```