### PR TITLE
Eslint d fix error without line number

### DIFF
--- a/lua/lint/linters/eslint_d.lua
+++ b/lua/lint/linters/eslint_d.lua
@@ -46,18 +46,18 @@ return require("lint.util").inject_cmd_exe({
             code = diagnostic.ruleId,
           })
           return diagnostics
+        else
+          table.insert(diagnostics, {
+            source = "eslint_d",
+            lnum = diagnostic.line - 1,
+            col = diagnostic.column - 1,
+            end_lnum = (diagnostic.endLine or diagnostic.line) - 1,
+            end_col = (diagnostic.endColumn or diagnostic.column) - 1,
+            severity = severities[diagnostic.severity],
+            message = diagnostic.message,
+            code = diagnostic.ruleId,
+          })
         end
-
-        table.insert(diagnostics, {
-          source = "eslint_d",
-          lnum = diagnostic.line - 1,
-          col = diagnostic.column - 1,
-          end_lnum = (diagnostic.endLine or diagnostic.line) - 1,
-          end_col = (diagnostic.endColumn or diagnostic.column) - 1,
-          severity = severities[diagnostic.severity],
-          message = diagnostic.message,
-          code = diagnostic.ruleId,
-        })
       end
     end
 

--- a/lua/lint/linters/eslint_d.lua
+++ b/lua/lint/linters/eslint_d.lua
@@ -45,7 +45,6 @@ return require("lint.util").inject_cmd_exe({
             message = diagnostic.message,
             code = diagnostic.ruleId,
           })
-          return diagnostics
         else
           table.insert(diagnostics, {
             source = "eslint_d",

--- a/lua/lint/linters/eslint_d.lua
+++ b/lua/lint/linters/eslint_d.lua
@@ -33,9 +33,21 @@ return require("lint.util").inject_cmd_exe({
     local diagnostics = {}
     if success and #messages > 0 then
       for _, diagnostic in ipairs(messages or {}) do
+        -- fix when error has no line value
         if diagnostic.line == nil then
+          table.insert(diagnostics, {
+            source = "eslint_d",
+            lnum = 0,
+            col = 0,
+            end_lnum = 0,
+            end_col = 0,
+            severity = severities[1],
+            message = diagnostic.message,
+            code = diagnostic.ruleId,
+          })
           return diagnostics
         end
+
         table.insert(diagnostics, {
           source = "eslint_d",
           lnum = diagnostic.line - 1,


### PR DESCRIPTION
This is a quick fix for eslint_d returning diagnostics without line numbers.  #416 
sorry for the formatting changes, this fixes the error I was having, I think the error was that sometimes eslint_d will return errors without line number, this will print that error in the first line of the file as a warning like it used to happen on previous versions, let me know what you think.