### PR TITLE
Remove linters extra cache; return nil instead of err

### DIFF
--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -29,12 +29,12 @@ local M = {}
 
 ---@type table<string, lint.Linter|fun():lint.Linter>
 M.linters = setmetatable({}, {
-  __index = function(tbl, key)
+  __index = function(_, key)
     local ok, linter = pcall(require, 'lint.linters.' .. key)
     if ok then
-      rawset(tbl, key, linter)
+      return linter
     end
-    return linter
+    return nil
   end,
 })
 


### PR DESCRIPTION
`require` already caches modules, no need to store them in a extra
table, it just messes with package.loaded cache reset.

Also fixes https://github.com/mfussenegger/nvim-lint/issues/408
