### PR TITLE
fix: parse eslint output with json

### DIFF
--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -1,30 +1,13 @@
 local binary_name = "eslint"
-
 local severities = {
   vim.diagnostic.severity.WARN,
   vim.diagnostic.severity.ERROR,
 }
 
-local diagnostic_translate_map = {
-  column = "col",
-  endColumn = "end_col",
-  endLine = "end_lnum",
-  line = "lnum",
-  message = "message",
-  ruleId = "code",
-  severity = "severity",
-}
-
 return require('lint.util').inject_cmd_exe({
   cmd = function()
     local local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
-    local stat = vim.loop.fs_stat(local_binary)
-
-    if stat then
-      return local_binary
-    end
-
-    return binary_name
+    return vim.loop.fs_stat(local_binary) and local_binary or binary_name
   end,
   args = {
     '--format',
@@ -36,47 +19,38 @@ return require('lint.util').inject_cmd_exe({
   stdin = true,
   stream = 'stdout',
   ignore_exitcode = true,
-  parser = function(output)
-    local success, decodedData = pcall(
-      vim.json.decode, output,
-      { luanil = { object = true, array = true } }
-    )
-    local json = decodedData and decodedData[1] and decodedData[1].messages or {}
+  parser = function(output, bufnr)
+    if vim.trim(output) == "" then
+      return {}
+    end
+    local decode_opts = { luanil = { object = true, array = true } }
+    local ok, data = pcall(vim.json.decode, output, decode_opts)
+    if not ok then
+      return {
+        {
+          bufnr = bufnr,
+          lnum = 0,
+          col = 0,
+          message = "Could not parse linter output due to: " .. data .. "\noutput: " .. output
+        }
+      }
+    end
+    -- See https://eslint.org/docs/latest/use/formatters/#json
     local diagnostics = {}
-
-    if success and #json > 0 then
-      for _, json_diagnostic in ipairs(json) do
-        local diagnostic = {}
-
-        -- Make fatal diagnostics appear on the first line.
-        if json_diagnostic.fatal then
-          diagnostic.col = 0
-          diagnostic.lnum = 0
-        end
-
-        -- Translate the json diagnostic to a diagnostic.
-        for json_key, diagnostic_key in pairs(diagnostic_translate_map) do
-          if json_diagnostic[json_key] ~= nil then
-            if json_key == 'severity' then
-              diagnostic[diagnostic_key] = severities[json_diagnostic[json_key]]
-            elseif type(json_diagnostic[json_key]) == "number" then
-              diagnostic[diagnostic_key] = json_diagnostic[json_key] - 1
-            else
-              diagnostic[diagnostic_key] = json_diagnostic[json_key]
-            end
-          end
-        end
-
-        -- Ensure that the diagnostic is populated with the required values.
-        if diagnostic.col and diagnostic.lnum then
-          table.insert(
-            diagnostics,
-            vim.tbl_extend("force", diagnostic, { source = binary_name })
-          )
-        end
+    for _, result in ipairs(data or {}) do
+      for _, msg in ipairs(result.messages or {}) do
+        table.insert(diagnostics, {
+          lnum = msg.line and (msg.line - 1) or 0,
+          end_lnum = msg.endLine and (msg.endLine - 1) or nil,
+          col = msg.column and (msg.column - 1) or 0,
+          end_col = msg.endColumn and (msg.endColumn - 1) or nil,
+          message = msg.message,
+          code = msg.ruleId,
+          severity = severities[msg.severity],
+          source = binary_name
+        })
       end
     end
-
     return diagnostics
   end
 })

--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -1,21 +1,34 @@
-local pattern = [[%s*(%d+):(%d+)%s+(%w+)%s+(.+%S)%s+(%S+)]]
-local groups = { 'lnum', 'col', 'severity', 'message', 'code' }
-local severity_map = {
-  ['error'] = vim.diagnostic.severity.ERROR,
-  ['warn'] = vim.diagnostic.severity.WARN,
-  ['warning'] = vim.diagnostic.severity.WARN,
+local binary_name = "eslint"
+
+local severities = {
+  vim.diagnostic.severity.WARN,
+  vim.diagnostic.severity.ERROR,
+}
+
+local diagnostic_translate_map = {
+  column = "col",
+  endColumn = "end_col",
+  endLine = "end_lnum",
+  line = "lnum",
+  message = "message",
+  ruleId = "code",
+  severity = "severity",
 }
 
 return require('lint.util').inject_cmd_exe({
   cmd = function()
-    local local_eslint = vim.fn.fnamemodify('./node_modules/.bin/eslint', ':p')
-    local stat = vim.loop.fs_stat(local_eslint)
+    local local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+    local stat = vim.loop.fs_stat(local_binary)
+
     if stat then
-      return local_eslint
+      return local_binary
     end
-    return 'eslint'
+
+    return binary_name
   end,
   args = {
+    '--format',
+    'json',
     '--stdin',
     '--stdin-filename',
     function() return vim.api.nvim_buf_get_name(0) end,
@@ -23,5 +36,39 @@ return require('lint.util').inject_cmd_exe({
   stdin = true,
   stream = 'stdout',
   ignore_exitcode = true,
-  parser = require('lint.parser').from_pattern(pattern, groups, severity_map, { ['source'] = 'eslint' }),
+  parser = function(output)
+    local success, decodedData = pcall(vim.json.decode, output)
+    local json = decodedData and decodedData[1] and decodedData[1].messages or {}
+    local diagnostics = {}
+
+    if success and #json > 0 then
+      for _, json_diagnostic in ipairs(json) do
+        local diagnostic = {}
+
+        -- Translate the json diagnostic to a diagnostic.
+        for json_key, diagnostic_key in pairs(diagnostic_translate_map) do
+          if json_diagnostic[json_key] ~= vim.NIL then
+            if json_key == 'severity' then
+              diagnostic[diagnostic_key] = severities[json_diagnostic[json_key]]
+            elseif type(json_diagnostic[json_key]) == "number" then
+              diagnostic[diagnostic_key] = json_diagnostic[json_key] - 1
+            else
+              diagnostic[diagnostic_key] = json_diagnostic[json_key]
+            end
+          end
+        end
+
+        -- Ensure that we have a diagnostic with `col` and `lnum` set, since
+        -- they are required.
+        if diagnostic.col and diagnostic.lnum then
+          table.insert(
+            diagnostics,
+            vim.tbl_extend("force", diagnostic, { source = binary_name })
+          )
+        end
+      end
+    end
+
+    return diagnostics
+  end
 })

--- a/lua/lint/linters/eslint_d.lua
+++ b/lua/lint/linters/eslint_d.lua
@@ -1,30 +1,8 @@
 local binary_name = "eslint_d"
-
-local severities = {
-  vim.diagnostic.severity.WARN,
-  vim.diagnostic.severity.ERROR,
-}
-
-local diagnostic_translate_map = {
-  column = "col",
-  endColumn = "end_col",
-  endLine = "end_lnum",
-  line = "lnum",
-  message = "message",
-  ruleId = "code",
-  severity = "severity",
-}
-
 return require('lint.util').inject_cmd_exe({
   cmd = function()
     local local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
-    local stat = vim.loop.fs_stat(local_binary)
-
-    if stat then
-      return local_binary
-    end
-
-    return binary_name
+    return vim.loop.fs_stat(local_binary) and local_binary or binary_name
   end,
   args = {
     '--format',
@@ -36,47 +14,11 @@ return require('lint.util').inject_cmd_exe({
   stdin = true,
   stream = 'stdout',
   ignore_exitcode = true,
-  parser = function(output)
-    local success, decodedData = pcall(
-      vim.json.decode, output,
-      { luanil = { object = true, array = true } }
-    )
-    local json = decodedData and decodedData[1] and decodedData[1].messages or {}
-    local diagnostics = {}
-
-    if success and #json > 0 then
-      for _, json_diagnostic in ipairs(json) do
-        local diagnostic = {}
-
-        -- Make fatal diagnostics appear on the first line.
-        if json_diagnostic.fatal then
-          diagnostic.col = 0
-          diagnostic.lnum = 0
-        end
-
-        -- Translate the json diagnostic to a diagnostic.
-        for json_key, diagnostic_key in pairs(diagnostic_translate_map) do
-          if json_diagnostic[json_key] ~= nil then
-            if json_key == 'severity' then
-              diagnostic[diagnostic_key] = severities[json_diagnostic[json_key]]
-            elseif type(json_diagnostic[json_key]) == "number" then
-              diagnostic[diagnostic_key] = json_diagnostic[json_key] - 1
-            else
-              diagnostic[diagnostic_key] = json_diagnostic[json_key]
-            end
-          end
-        end
-
-        -- Ensure that the diagnostic is populated with the required values.
-        if diagnostic.col and diagnostic.lnum then
-          table.insert(
-            diagnostics,
-            vim.tbl_extend("force", diagnostic, { source = binary_name })
-          )
-        end
-      end
+  parser = function(output, bufnr)
+    local result = require("lint.linters.eslint").parser(output, bufnr)
+    for _, d in ipairs(result) do
+      d.source = binary_name
     end
-
-    return diagnostics
+    return result
   end
 })

--- a/lua/lint/linters/eslint_d.lua
+++ b/lua/lint/linters/eslint_d.lua
@@ -1,21 +1,34 @@
-local pattern = [[%s*(%d+):(%d+)%s+(%w+)%s+(.+%S)%s+(%S+)]]
-local groups = { 'lnum', 'col', 'severity', 'message', 'code' }
-local severity_map = {
-  ['error'] = vim.diagnostic.severity.ERROR,
-  ['warn'] = vim.diagnostic.severity.WARN,
-  ['warning'] = vim.diagnostic.severity.WARN,
+local binary_name = "eslint_d"
+
+local severities = {
+  vim.diagnostic.severity.WARN,
+  vim.diagnostic.severity.ERROR,
+}
+
+local diagnostic_translate_map = {
+  column = "col",
+  endColumn = "end_col",
+  endLine = "end_lnum",
+  line = "lnum",
+  message = "message",
+  ruleId = "code",
+  severity = "severity",
 }
 
 return require('lint.util').inject_cmd_exe({
   cmd = function()
-    local local_eslintd = vim.fn.fnamemodify('./node_modules/.bin/eslint_d', ':p')
-    local stat = vim.loop.fs_stat(local_eslintd)
+    local local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+    local stat = vim.loop.fs_stat(local_binary)
+
     if stat then
-      return local_eslintd
+      return local_binary
     end
-    return 'eslint_d'
+
+    return binary_name
   end,
   args = {
+    '--format',
+    'json',
     '--stdin',
     '--stdin-filename',
     function() return vim.api.nvim_buf_get_name(0) end,
@@ -23,5 +36,39 @@ return require('lint.util').inject_cmd_exe({
   stdin = true,
   stream = 'stdout',
   ignore_exitcode = true,
-  parser = require('lint.parser').from_pattern(pattern, groups, severity_map, { ['source'] = 'eslint_d' }),
+  parser = function(output)
+    local success, decodedData = pcall(vim.json.decode, output)
+    local json = decodedData and decodedData[1] and decodedData[1].messages or {}
+    local diagnostics = {}
+
+    if success and #json > 0 then
+      for _, json_diagnostic in ipairs(json) do
+        local diagnostic = {}
+
+        -- Translate the json diagnostic to a diagnostic.
+        for json_key, diagnostic_key in pairs(diagnostic_translate_map) do
+          if json_diagnostic[json_key] ~= vim.NIL then
+            if json_key == 'severity' then
+              diagnostic[diagnostic_key] = severities[json_diagnostic[json_key]]
+            elseif type(json_diagnostic[json_key]) == "number" then
+              diagnostic[diagnostic_key] = json_diagnostic[json_key] - 1
+            else
+              diagnostic[diagnostic_key] = json_diagnostic[json_key]
+            end
+          end
+        end
+
+        -- Ensure that we have a diagnostic with `col` and `lnum` set, since
+        -- they are required.
+        if diagnostic.col and diagnostic.lnum then
+          table.insert(
+            diagnostics,
+            vim.tbl_extend("force", diagnostic, { source = binary_name })
+          )
+        end
+      end
+    end
+
+    return diagnostics
+  end
 })

--- a/tests/eslint_d_spec.lua
+++ b/tests/eslint_d_spec.lua
@@ -58,6 +58,22 @@ describe("linter.eslint_d", function()
     assert.are.same(1, #result)
   end)
 
+  it('should show fatal diagnostics on the first line', function()
+    local parser = require("lint.linters.eslint_d").parser
+
+    local json = '[{ "messages": [ { "fatal": true, "message": "fatal", "severity": 2 } ]}]'
+    local result = parser(json)
+
+    assert.are.same(1, #result)
+    assert.are.same({
+      col = 0,
+      lnum = 0,
+      message = "fatal",
+      severity = vim.diagnostic.severity.ERROR,
+      source = "eslint_d"
+    }, result[1])
+  end)
+
   it('should parse valid diagnostics', function()
     local parser = require("lint.linters.eslint_d").parser
 

--- a/tests/eslint_d_spec.lua
+++ b/tests/eslint_d_spec.lua
@@ -13,10 +13,31 @@ describe("linter.eslint_d", function()
   1:10  error  'testFunc' is defined but never used                                                                                   no-unused-vars
   4:16  error  This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain  no-dupe-else-if
 
-✖ 2 problems (2 errors, 0 warnings)
-    ]],
-      vim.api.nvim_get_current_buf()
-    )
+    local result = parser([[
+[{
+  "messages": [
+    {
+      "column": 10,
+      "endColumn": 18,
+      "endLine": 1,
+      "line": 1,
+      "message": "'testFunc' is defined but never used",
+      "ruleId": "no-unused-vars",
+      "severity": 2
+    },
+    {
+      "column": 16,
+      "endColumn": 22,
+      "endLine": 4,
+      "line": 4,
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain",
+      "ruleId": "no-dupe-else-if",
+      "severity": 2
+    }
+  ]
+}]
+]])
+
     assert.are.same(2, #result)
     local expected_1 = {
       code = "no-unused-vars",
@@ -41,7 +62,8 @@ describe("linter.eslint_d", function()
       end_col = 15,
       end_lnum = 3,
       lnum = 3,
-      message = "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain",
+      message =
+      "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain",
       severity = 1,
       source = "eslint_d",
       user_data = {

--- a/tests/eslint_d_spec.lua
+++ b/tests/eslint_d_spec.lua
@@ -11,13 +11,19 @@ describe("linter.eslint_d", function()
 
     local json = '{]'
     local result = parser(json)
-
-    assert.are.same(0, #result)
+    local expected = {
+      {
+        lnum = 0,
+        col = 0,
+        message = "Could not parse linter output due to: Expected object key string but found T_ARR_END at character 2\noutput: {]",
+        source = "eslint_d",
+      }
+    }
+    assert.are.same(expected, result)
   end)
 
-  it('should skip invalid diagnostics', function()
+  it('uses 0 defaults for missing line/column', function()
     local parser = require("lint.linters.eslint_d").parser
-
     local json = '[{ "messages": [' ..
         -- Valid JSON diagnostic.
         [[
@@ -55,7 +61,9 @@ describe("linter.eslint_d", function()
         ]] .. ']}]'
     local result = parser(json)
 
-    assert.are.same(1, #result)
+    assert.are.same(3, #result)
+    assert.are.same(0, result[2].lnum)
+    assert.are.same(0, result[3].col)
   end)
 
   it('should show fatal diagnostics on the first line', function()


### PR DESCRIPTION
This PR aims to parse `eslint` JSON output, which will improve the diagnostics since it allows you to get more information, like `end_col`.