### PR TITLE
fix: support end col for mypy

### DIFF
--- a/lua/lint/linters/mypy.lua
+++ b/lua/lint/linters/mypy.lua
@@ -1,6 +1,6 @@
 -- path/to/file:line:col: severity: message
-local pattern = '([^:]+):(%d+):(%d+): (%a+): (.*)'
-local groups = { 'file', 'lnum', 'col', 'severity', 'message' }
+local pattern = '([^:]+):(%d+):(%d+):(%d+):(%d+): (%a+): (.*)'
+local groups = { 'file', 'lnum', 'col', 'end_lnum', 'end_col', 'severity', 'message' }
 local severities = {
   error = vim.diagnostic.severity.ERROR,
   warning = vim.diagnostic.severity.WARN,
@@ -13,11 +13,18 @@ return {
   ignore_exitcode = true,
   args = {
     '--show-column-numbers',
+    '--show-error-end',
     '--hide-error-codes',
     '--hide-error-context',
     '--no-color-output',
     '--no-error-summary',
     '--no-pretty',
   },
-  parser = require('lint.parser').from_pattern(pattern, groups, severities, { ['source'] = 'mypy' }),
+  parser = require('lint.parser').from_pattern(
+    pattern,
+    groups,
+    severities,
+    { ['source'] = 'mypy' },
+    { end_col_offset = 0 }
+  ),
 }

--- a/tests/mypy_spec.lua
+++ b/tests/mypy_spec.lua
@@ -1,0 +1,35 @@
+describe('linter.mypy', function()
+  it('can parse the output', function()
+    local parser = require('lint.linters.mypy').parser
+    local bufnr = vim.uri_to_bufnr('file:///foo.py')
+    local output = [[
+/foo.py:10:15:10:20: error: Incompatible return value type (got "str", expected "bool")
+/foo.py:20:25:20:30: error: Argument 1 to "foo" has incompatible type "str"; expected "int"
+]]
+    local result = parser(output, bufnr)
+
+    assert.are.same(2, #result)
+
+    local expected_error = {
+      source = 'mypy',
+      message = 'Incompatible return value type (got "str", expected "bool")',
+      lnum = 9,
+      col = 14,
+      end_lnum = 9,
+      end_col = 20,
+      severity = vim.diagnostic.severity.ERROR,
+    }
+    assert.are.same(expected_error, result[1])
+
+    local expected_warning = {
+      source = 'mypy',
+      message = 'Argument 1 to "foo" has incompatible type "str"; expected "int"',
+      lnum = 19,
+      col = 24,
+      end_lnum = 19,
+      end_col = 30,
+      severity = vim.diagnostic.severity.ERROR,
+    }
+    assert.are.same(expected_warning, result[2])
+  end)
+end)


### PR DESCRIPTION
This PR adds end column support for the `mypy` linter.

Also, there was no existing test coverage for this linter, so I added it. Tests are passing locally.