### PR TITLE
sqlfluff: Remove 'None' lines from output

### DIFF
--- a/lua/lint/linters/sqlfluff.lua
+++ b/lua/lint/linters/sqlfluff.lua
@@ -10,6 +10,7 @@ return {
   parser = function(output, _)
     local per_filepath = {}
     if #output > 0 then
+      output = output:gsub("None\n", "")
       local status, decoded = pcall(vim.json.decode, output)
       if not status then
         per_filepath = {


### PR DESCRIPTION
sqlfluff occasionally exhibits weird behaviour where it will break in the middle of linting and display a line that just reads `None` instead of showing JSON output:

<img width="1563" alt="sqlfluff_cli" src="https://github.com/mfussenegger/nvim-lint/assets/685798/0be6c2b1-a823-41b9-a5ea-46d422f2472a">

It will then continue linting and eventually print the proper JSON output. However, the initial `None` line becomes part of the `output` string in the parser, which leads to a `jsondecodeerror` and makes nvim-lint just display the raw output on line 1 of the buffer:

<img width="1517" alt="sqlfluff_nvim_incorrect" src="https://github.com/mfussenegger/nvim-lint/assets/685798/489c51aa-f2b5-4a36-9353-f5f486562dc1">

If we strip the `None` line from the output, the diagnostic is displayed correctly:

<img width="901" alt="sqlfluff_nvim_correct" src="https://github.com/mfussenegger/nvim-lint/assets/685798/9dec3cf4-85c6-4850-b58c-139726e1155a">
