### PR TITLE
Fixed cpplint error on windows with inject_cmd_exe

### DIFF
--- a/lua/lint/linters/cpplint.lua
+++ b/lua/lint/linters/cpplint.lua
@@ -2,7 +2,7 @@
 local pattern = '([^:]+):(%d+):  (.+)  (.+)'
 local groups = { 'file', 'lnum', 'message', 'code'}
 
-return {
+return require('lint.util').inject_cmd_exe({
   cmd = 'cpplint',
   stdin = false,
   args = {},
@@ -12,4 +12,4 @@ return {
     ['source'] = 'cpplint',
     ['severity'] = vim.diagnostic.severity.WARN,
   }),
-}
+})


### PR DESCRIPTION
Fixed #445 using `utils.inject_cmd_exe`.