### PR TITLE
fix(ruff): do not ignore the exit code

### DIFF
--- a/lua/lint/linters/ruff.lua
+++ b/lua/lint/linters/ruff.lua
@@ -16,7 +16,7 @@ return {
     '--no-fix',
     '-',
   },
-  ignore_exitcode = true,
+  ignore_exitcode = false,
   parser = require('lint.parser').from_pattern(pattern, groups, nil, {
     ['source'] = 'ruff',
     ['severity'] = vim.diagnostic.severity.WARN,


### PR DESCRIPTION
With this fix the `ruff` diagnostics get shown on my neovim screen.