### PR TITLE
shellcheck: add Windows support

### DIFF
--- a/lua/lint/linters/shellcheck.lua
+++ b/lua/lint/linters/shellcheck.lua
@@ -5,7 +5,7 @@ local severities = {
   style = vim.diagnostic.severity.HINT,
 }
 
-return {
+return require('lint.util').inject_cmd_exe({
   cmd = 'shellcheck',
   stdin = true,
   args = {
@@ -36,4 +36,4 @@ return {
     end
     return diagnostics
   end,
-}
+})


### PR DESCRIPTION
Adds Windows support for `shellcheck`.

Thanks for your work on this plugin!