### PR TITLE
Add `zsh` linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Other dedicated linters that are built-in are:
 | [yamllint][yamllint]               | `yamllint`             |
 | [tfsec][tfsec]                     | `tfsec`                |
 | [trivy][trivy]                     | `trivy`                |
+| [zsh][zsh]                         | `zsh`                  |
 
 ## Custom Linters
 
@@ -433,3 +434,4 @@ busted tests/
 [gitlint]: https://github.com/jorisroovers/gitlint
 [pflake8]: https://github.com/csachs/pyproject-flake8
 [fish]: https://github.com/fish-shell/fish-shell
+[zsh]: https://www.zsh.org/

--- a/lua/lint/linters/zsh.lua
+++ b/lua/lint/linters/zsh.lua
@@ -1,0 +1,11 @@
+return {
+  cmd = "zsh",
+  stdin = false,
+  ignore_exitcode = true,
+  args = { "--no-exec" },
+  stream = "stderr",
+  parser = require("lint.parser").from_errorformat("%f:%l:%m", {
+    source = "zsh",
+    severity = vim.diagnostic.severity.ERROR,
+  }),
+}


### PR DESCRIPTION
uses `zsh --no-exec`, similar to `fish`