### PR TITLE
Added inject_cmd_exe to pylint, flake8 and ruff

### DIFF
--- a/lua/lint/linters/flake8.lua
+++ b/lua/lint/linters/flake8.lua
@@ -2,7 +2,7 @@
 local pattern = '[^:]+:(%d+):(%d+):(%w+):(.+)'
 local groups = { 'lnum', 'col', 'code', 'message' }
 
-return {
+return require('lint.util').inject_cmd_exe({
   cmd = 'flake8',
   stdin = true,
   args = {
@@ -15,4 +15,4 @@ return {
     ['source'] = 'flake8',
     ['severity'] = vim.diagnostic.severity.WARN,
   }),
-}
+})

--- a/lua/lint/linters/pylint.lua
+++ b/lua/lint/linters/pylint.lua
@@ -7,7 +7,7 @@ local severities = {
   convention = vim.diagnostic.severity.HINT,
 }
 
-return {
+return require('lint.util').inject_cmd_exe({
   cmd = 'pylint',
   stdin = false,
   args = {
@@ -42,4 +42,4 @@ return {
     end
     return diagnostics
   end,
-}
+})

--- a/lua/lint/linters/ruff.lua
+++ b/lua/lint/linters/ruff.lua
@@ -9,7 +9,7 @@ local severities = {
   ["E999"] = error, -- `SyntaxError`
 }
 
-return {
+return require('lint.util').inject_cmd_exe({
   cmd = "ruff",
   stdin = true,
   args = {
@@ -45,4 +45,4 @@ return {
     end
     return diagnostics
   end,
-}
+})


### PR DESCRIPTION
Fixes ENOENT when running this linters on Windows:
- pylint
- flake8
- ruff

Fixed #470  using utils.inject_cmd_exe.