### PR TITLE
Make actionlint actually use stdin

### DIFF
--- a/lua/lint/linters/actionlint.lua
+++ b/lua/lint/linters/actionlint.lua
@@ -13,19 +13,15 @@ return {
     end
     local diagnostics = {}
     for _, item in ipairs(decoded) do
-      local current_file = vim.api.nvim_buf_get_name(bufnr)
-      local linted_file = vim.fn.getcwd() .. '/' .. item.filepath
-      if current_file == linted_file or item.filepath == "<stdin>" then
-        table.insert(diagnostics, {
-          lnum = item.line - 1,
-          end_lnum = item.line - 1,
-          col = item.column - 1,
-          end_col = item.end_column,
-          severity = vim.diagnostic.severity.WARN,
-          source = 'actionlint: ' .. item.kind,
-          message = item.message,
-        })
-      end
+      table.insert(diagnostics, {
+        lnum = item.line - 1,
+        end_lnum = item.line - 1,
+        col = item.column - 1,
+        end_col = item.end_column,
+        severity = vim.diagnostic.severity.WARN,
+        source = 'actionlint: ' .. item.kind,
+        message = item.message,
+      })
     end
     return diagnostics
   end,

--- a/lua/lint/linters/actionlint.lua
+++ b/lua/lint/linters/actionlint.lua
@@ -3,7 +3,7 @@ return {
   stdin = true,
   args = { '-format', '{{json .}}', '-' },
   ignore_exitcode = true,
-  parser = function(output, bufnr)
+  parser = function(output)
     if output == '' then
       return {}
     end

--- a/lua/lint/linters/actionlint.lua
+++ b/lua/lint/linters/actionlint.lua
@@ -1,7 +1,7 @@
 return {
   cmd = 'actionlint',
   stdin = true,
-  args = { '-format', '{{json .}}' },
+  args = { '-format', '{{json .}}', '-' },
   ignore_exitcode = true,
   parser = function(output, bufnr)
     if output == '' then
@@ -15,7 +15,7 @@ return {
     for _, item in ipairs(decoded) do
       local current_file = vim.api.nvim_buf_get_name(bufnr)
       local linted_file = vim.fn.getcwd() .. '/' .. item.filepath
-      if current_file == linted_file then
+      if current_file == linted_file or item.filepath == "<stdin>" then
         table.insert(diagnostics, {
           lnum = item.line - 1,
           end_lnum = item.line - 1,


### PR DESCRIPTION
This PR makes `actionlint` read from `stdin`, see https://github.com/rhysd/actionlint/blob/0b676b1171cb62a16e4f942100cf046aa04aef21/docs/usage.md?plain=1#L20-L24.

I am not sure if check on line 18 is actually necessary. `actionlint`, when invoked without any arguments will [look for workflows in current repository](https://github.com/rhysd/actionlint/blob/0b676b1171cb62a16e4f942100cf046aa04aef21/docs/usage.md?plain=1#L8-L12), and only check [paths when given](https://github.com/rhysd/actionlint/blob/0b676b1171cb62a16e4f942100cf046aa04aef21/docs/usage.md?plain=1#L14-L18) some.

Currently `actionlint` is set up such that:`stdin = true` but no `-` in `args` results in no filename being passed to `args` and `actionlint` checking entire repository for workflow files. Therefore that check on line 18 is necessary.

I suggest removing that check entirely and rely on `stdin` functionality.

Alternatively `stdin` should be set to `false` causing filename to be passed to `args` also rendering that conditional unnecessary.