### PR TITLE
Add support for `prisma-lint`

### DIFF
--- a/lua/lint/linters/prisma_lint.lua
+++ b/lua/lint/linters/prisma_lint.lua
@@ -1,0 +1,35 @@
+local binary_name = "prisma-lint"
+
+return require('lint.util').inject_cmd_exe({
+  cmd = function()
+    local local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+    return vim.loop.fs_stat(local_binary) and local_binary or binary_name
+  end,
+  stdin = false,
+  args = {
+    "--output-format",
+    "json"
+  },
+  append_fname = true,
+  stream = 'both',
+  ignore_exitcode = true,
+  parser = function(output)
+    local decoded = vim.json.decode(output)
+    local diagnostics = {}
+    if decoded == nil then
+      return diagnostics
+    end
+    for _, violation in pairs(decoded["violations"]) do
+      local location = violation.location
+      table.insert(diagnostics, {
+        lnum = location.startLine - 1,
+        end_lnum = location.endLine - 1,
+        col = location.startColumn - 1,
+        -- endColumn is inclusive, but end_col is exclusive.
+        end_col = location.endColumn,
+        message = violation.message,
+      })
+    end
+    return diagnostics
+  end,
+})

--- a/lua/lint/linters/prisma_lint.lua
+++ b/lua/lint/linters/prisma_lint.lua
@@ -22,12 +22,15 @@ return require('lint.util').inject_cmd_exe({
     for _, violation in pairs(decoded["violations"]) do
       local location = violation.location
       table.insert(diagnostics, {
+        source = binary_name,
         lnum = location.startLine - 1,
         end_lnum = location.endLine - 1,
         col = location.startColumn - 1,
         -- endColumn is inclusive, but end_col is exclusive.
         end_col = location.endColumn,
         message = violation.message,
+        code = violation.ruleName,
+        severity = vim.diagnostic.severity.ERROR,
       })
     end
     return diagnostics

--- a/tests/prisma_lint_spec.lua
+++ b/tests/prisma_lint_spec.lua
@@ -1,0 +1,83 @@
+describe('linter.prisma_lint', function()
+  it('can parse prisma-lint output', function()
+    local parser = require('lint.linters.prisma_lint').parser
+    local result = parser([[
+{
+  "violations": [
+    {
+      "ruleName": "model-name-mapping-snake-case",
+      "message": "Model name must be mapped to \"user\".",
+      "fileName": "/example/invalid-simple.prisma",
+      "location": {
+        "startLine": 1,
+        "startColumn": 1,
+        "endLine": 1,
+        "endColumn": 12
+      }
+    },
+    {
+      "ruleName": "require-field",
+      "message": "Missing required fields: \"createdAt\".",
+      "fileName": "/example/invalid-simple.prisma",
+      "location": {
+        "startLine": 1,
+        "startColumn": 1,
+        "endLine": 1,
+        "endColumn": 12
+      }
+    },
+    {
+      "ruleName": "field-name-mapping-snake-case",
+      "message": "Field name must be mapped to snake case.",
+      "fileName": "/example/invalid-simple.prisma",
+      "location": {
+        "startLine": 3,
+        "startColumn": 3,
+        "endLine": 3,
+        "endColumn": 8
+      }
+    }
+  ]
+}
+]])
+
+    assert.are.same(3, #result)
+
+    local expected_1 = {
+      source = 'prisma_lint',
+      lnum = 0,
+      col = 0,
+      end_lnum = 0,
+      end_col = 12,
+      severity = vim.diagnostic.severity.HINT,
+      message = 'Model name must be mapped to "user".',
+      code = 'model-name-mapping-snake-case',
+    }
+
+    assert.are.same(expected_1, result[1])
+
+    local expected_2 = {
+      source = 'prisma_lint',
+      lnum = 0,
+      col = 0,
+      end_lnum = 0,
+      end_col = 12,
+      severity = vim.diagnostic.severity.HINT,
+      message = 'Missing required fields: "createdAt".',
+      code = 'require-field',
+    }
+
+    assert.are.same(expected_2, result[2])
+
+    local expected_3 = {
+      source = 'prisma_lint',
+      lnum = 2,
+      col = 2,
+      end_lnum = 2,
+      end_col = 8,
+      severity = vim.diagnostic.severity.HINT,
+      message = 'Field name must be mapped to snake case.',
+      code = 'field-name-mapping-snake-case',
+    }
+  end)
+end)

--- a/tests/prisma_lint_spec.lua
+++ b/tests/prisma_lint_spec.lua
@@ -44,12 +44,12 @@ describe('linter.prisma_lint', function()
     assert.are.same(3, #result)
 
     local expected_1 = {
-      source = 'prisma_lint',
+      source = 'prisma-lint',
       lnum = 0,
       col = 0,
       end_lnum = 0,
       end_col = 12,
-      severity = vim.diagnostic.severity.HINT,
+      severity = vim.diagnostic.severity.ERROR,
       message = 'Model name must be mapped to "user".',
       code = 'model-name-mapping-snake-case',
     }
@@ -57,12 +57,12 @@ describe('linter.prisma_lint', function()
     assert.are.same(expected_1, result[1])
 
     local expected_2 = {
-      source = 'prisma_lint',
+      source = 'prisma-lint',
       lnum = 0,
       col = 0,
       end_lnum = 0,
       end_col = 12,
-      severity = vim.diagnostic.severity.HINT,
+      severity = vim.diagnostic.severity.ERROR,
       message = 'Missing required fields: "createdAt".',
       code = 'require-field',
     }
@@ -70,14 +70,16 @@ describe('linter.prisma_lint', function()
     assert.are.same(expected_2, result[2])
 
     local expected_3 = {
-      source = 'prisma_lint',
+      source = 'prisma-lint',
       lnum = 2,
       col = 2,
       end_lnum = 2,
       end_col = 8,
-      severity = vim.diagnostic.severity.HINT,
+      severity = vim.diagnostic.severity.ERROR,
       message = 'Field name must be mapped to snake case.',
       code = 'field-name-mapping-snake-case',
     }
+
+    assert.are.same(expected_3, result[3])
   end)
 end)


### PR DESCRIPTION
I recently added a JSON output format to `prisma-lint` to support editor integrations: https://github.com/loop-payments/prisma-lint

<img width="927" alt="image" src="https://github.com/mfussenegger/nvim-lint/assets/1289501/83dc2c76-02e4-40e5-95e6-a05427f64ee0">
