### PR TITLE
Ignore exitcode for clang-tidy

### DIFF
--- a/lua/lint/linters/clangtidy.lua
+++ b/lua/lint/linters/clangtidy.lua
@@ -13,5 +13,6 @@ return {
   cmd = 'clang-tidy',
   stdin = false,
   args = { '--quiet' },
+  ignore_exitcode = true,
   parser = require('lint.parser').from_pattern(pattern, groups, severity_map, { ['source'] = 'clang-tidy' }),
 }


### PR DESCRIPTION
Current clang-tidy linter is not working, because clang-tidy returns exit code 1 if linting produces errors.