### PR TITLE
Store bufnr into diagnostic_structure, so that it will get publish for each buffer

### DIFF
--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -19,12 +19,14 @@ function M.from_errorformat(efm, skeleton)
     local result = {}
     for _, item in pairs(qflist.items) do
       if item.valid == 1 then
+        local bufnr = item.bufnr
         local lnum = math.max(0, item.lnum - 1)
         local col = math.max(0, item.col - 1)
         local end_lnum = item.end_lnum > 0 and (item.end_lnum - 1) or lnum
         local end_col = item.end_col > 0 and (item.end_col - 1) or col
         local severity = item.type ~= "" and severity_by_qftype[item.type:upper()] or nil
         local diagnostic = {
+          bufnr = bufnr,
           lnum = lnum,
           col = col,
           end_lnum = end_lnum,

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -149,7 +149,13 @@ function M.accumulate_chunks(parse)
               }
             }
           end
-          publish(diagnostics, bufnr)
+          local local_diagnostics = {}
+          for _, diagnostic in ipairs(diagnostics) do
+            if diagnostic.bufnr == bufnr then
+              table.insert(local_diagnostics, diagnostic)
+            end
+          end
+          publish(local_diagnostics, bufnr)
         else
           publish({}, bufnr)
         end


### PR DESCRIPTION
Some project level linter will generate diagnostics for all files in the project, and the origin implementation does not distinguish between the bufnr of each diagnostic message. This PR put `bufnr` into the field of diagnostic messages, so that these messages can be filtered against certain buffer on output.