### PR TITLE
fix(tflint): path match

### DIFF
--- a/lua/lint/linters/tflint.lua
+++ b/lua/lint/linters/tflint.lua
@@ -14,13 +14,10 @@ return {
     local decoded = vim.json.decode(output) or {}
     local issues = decoded["issues"] or {}
     local diagnostics = {}
-    local buf_path = vim.api.nvim_buf_get_name(bufnr)
-    for _, issue in ipairs(issues) do
-      -- bug: tflint _may_ eat first «/»
-      local issue_path = "/" .. issue.range.filename
-      issue_path = string.gsub(issue_path, "^//", "/")
+    local buf_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t")
 
-      if issue_path == buf_path then
+    for _, issue in ipairs(issues) do
+      if issue.range.filename == buf_path then
         table.insert(diagnostics, {
           lnum = assert(tonumber(issue.range.start.line)),
           end_lnum = assert(tonumber(issue.range['end'].line)),

--- a/tests/tflint_spec.lua
+++ b/tests/tflint_spec.lua
@@ -3,8 +3,9 @@ describe('linter.tflint', function()
     local parser = require('lint.linters.tflint').parser
     local bufnr = vim.uri_to_bufnr('file:///main.tf')
     local result = parser(
-      [[{"issues":[{"rule":{"name":"terraform_required_providers","severity":"warning","link":"https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md"},"message":"Missing version constraint for provider \"aws\" in \"required_providers\"","range":{"filename":"/main.tf","start":{"line":19,"column":1},"end":{"line":19,"column":15}},"callers":[]}],"errors":[]}]],
-      bufnr)
+      [[{"issues":[{"rule":{"name":"terraform_required_providers","severity":"warning","link":"https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md"},"message":"Missing version constraint for provider \"aws\" in \"required_providers\"","range":{"filename":"main.tf","start":{"line":19,"column":1},"end":{"line":19,"column":15}},"callers":[]}],"errors":[]}]],
+      bufnr
+    )
     assert.are.same(1, #result)
     local expected = {
       source = 'tflint',


### PR DESCRIPTION
👋  Thank you for all the work to maintain this plugin!

What
---
Update filename match to check relative path instead of absolute path.

Why
---
[`vim.api.nvim_buf_get_name(bufnr)`](https://neovim.io/doc/user/api.html#nvim_buf_get_name()) gets the full path name, but `tflint` only returns the relative path from the root of the project.
Use [`vim.fn.expand("%")`](https://neovim.io/doc/user/builtin.html#expand()) returns the current filename that is open in the buffer.

Example:
```sh
$ tflint --format=json | jq
{
  "issues": [
    {
      "rule": {
        "name": "terraform_typed_variables",
        "severity": "warning",
        "link": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_typed_variables.md"
      },
      "message": "`not_used` variable has no type",
      "range": {
        "filename": "main.tf",
        "start": {
          "line": 1,
          "column": 1
        },
        "end": {
          "line": 1,
          "column": 20
        }
      },
      "callers": []
    },
  ],
  "errors": []
}
```

