### PR TITLE
Support finding eslint in root node_modules

### DIFF
--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -4,10 +4,21 @@ local severities = {
   vim.diagnostic.severity.ERROR,
 }
 
+local function get_local_binary()
+  local files = vim.fs.find({ 'node_modules' }, { upward = true, limit = 3 })
+  for _, dir in ipairs(files) do
+    local path = dir .. '/.bin/' .. binary_name
+    local stat = vim.uv.fs_stat(path)
+    if stat then
+      return path
+    end
+  end
+end
+
 return {
   cmd = function()
-    local local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
-    return vim.loop.fs_stat(local_binary) and local_binary or binary_name
+    local local_binary = get_local_binary()
+    return local_binary or binary_name
   end,
   args = {
     '--format',


### PR DESCRIPTION
When working in a workspace there might be multiple node_modules folders and eslint might not be in the closest one. User find() to search multiple folders

I'm not sure about the limit being set to 3 but it seemed like a small enough number which would work for most repos. That's a guess though.

I haven't been able to run the tests yet because busted is complaining about `attempt to index a nil value (global 'vim')`. I've read some about running it through neovim but haven't understood it yet.
