### PR TITLE
Return all linters in get_running; add bufnr filter; fix proc cleanup

### DIFF
--- a/tests/loop.py
+++ b/tests/loop.py
@@ -1,0 +1,8 @@
+import asyncio
+
+
+async def sleep():
+    while True:
+        await asyncio.sleep(1)
+
+asyncio.run(sleep())


### PR DESCRIPTION
Alternative for https://github.com/mfussenegger/nvim-lint/pull/483
Should also fix https://github.com/mfussenegger/nvim-lint/issues/484
