### PR TITLE
feat: add dash linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Other dedicated linters that are built-in are:
 | [credo][credo]                     | `credo`                |
 | [cspell][36]                       | `cspell`               |
 | [curlylint][curlylint]             | `curlylint`            |
+| [dash][dash]                       | `dash`                 |
 | [deno][deno]                       | `deno`                 |
 | [djlint][djlint]                   | `djlint`               |
 | [dotenv-linter][dotenv-linter]     | `dotenv_linter`        |
@@ -474,3 +475,4 @@ busted tests/
 [zsh]: https://www.zsh.org/
 [typos]: https://github.com/crate-ci/typos
 [joker]: https://github.com/candid82/joker
+[dash]: http://gondor.apana.org.au/~herbert/dash

--- a/lua/lint/linters/dash.lua
+++ b/lua/lint/linters/dash.lua
@@ -1,0 +1,14 @@
+local pattern = "(.+): (%d+): (.+)"
+local groups = { "file", "lnum", "message" }
+
+return {
+  cmd = "dash",
+  stdin = false,
+  ignore_exitcode = true,
+  args = { "-n" },
+  stream = "stderr",
+  parser = require("lint.parser").from_pattern(pattern, groups, nil, {
+    ["source"] = "dash",
+    ["severity"] = vim.diagnostic.severity.ERROR,
+  }),
+}


### PR DESCRIPTION
Uses `dash -n` to check syntax of shell scripts without executing them.
This is similar to `zsh --no-exec` and `fish --no-execute`.