### PR TITLE
Add `--stdin-display-name` option for flake8 linter

### DIFF
--- a/lua/lint/linters/flake8.lua
+++ b/lua/lint/linters/flake8.lua
@@ -8,6 +8,8 @@ return {
   args = {
     '--format=%(path)s:%(row)d:%(col)d:%(code)s:%(text)s',
     '--no-show-source',
+    '--stdin-display-name',
+    function() return vim.api.nvim_buf_get_name(0) end,
     '-',
   },
   ignore_exitcode = true,


### PR DESCRIPTION
flake8 can be configured based on file path, to ignore certain files or change config options. But it only works if we pass in `--stdin-display-name`