### PR TITLE
fix(lua/lint/parser.lua): `from_errorformat` and `stdin = true` parsers

### DIFF
--- a/lua/lint/linters/credo.lua
+++ b/lua/lint/linters/credo.lua
@@ -1,4 +1,4 @@
-local errorfmt = '[%t] %. %f:%l:%c %m, [%t] %. %f:%l %m'
+local errorfmt = '[%t] %. stdin:%l:%c %m, [%t] %. stdin:%l %m'
 
 return {
   cmd = 'mix',
@@ -8,5 +8,3 @@ return {
   ignore_exitcode = true, -- credo only returns 0 if there are no errors
   parser = require('lint.parser').from_errorformat(errorfmt, { ['source'] = 'credo' })
 }
-
-

--- a/lua/lint/linters/statix.lua
+++ b/lua/lint/linters/statix.lua
@@ -4,7 +4,7 @@ return {
   args = {'check', '-o', 'errfmt', '--stdin'},
   stream = 'stdout',
   ignore_exitcode = true, -- statix only returns 0 if there are no errors
-  parser = require('lint.parser').from_errorformat('%f>%l:%c:%t:%n:%m', {
+  parser = require('lint.parser').from_errorformat('<stdin>>%l:%c:%t:%n:%m', {
     source = 'statix'
   })
 }

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -18,7 +18,7 @@ function M.from_errorformat(efm, skeleton)
     local qflist = vim.fn.getqflist({ efm = efm, lines = lines })
     local result = {}
     for _, item in pairs(qflist.items) do
-      if item.valid == 1 and (bufnr == nil or item.bufnr == bufnr) then
+      if item.valid == 1 and (bufnr == nil or item.bufnr == 0 or item.bufnr == bufnr) then
         local lnum = math.max(0, item.lnum - 1)
         local col = math.max(0, item.col - 1)
         local end_lnum = item.end_lnum > 0 and (item.end_lnum - 1) or lnum

--- a/tests/credo_spec.lua
+++ b/tests/credo_spec.lua
@@ -4,8 +4,8 @@ describe('linter.credo', function()
     -- taken from example screenshot from credo's documentation https://hexdocs.pm/credo/overview.html
     -- 3rd record shouldn't get picked up because there is no file/line information
     local result = parser([[
-[R] → lib/mix/tasks/my_task.ex:1:11 Unless conditions should avoid having an `else` block.
-[W] ↗ lib/my_project.ex:9:5 Use `reraise` inside a rescue block to preserve the original stacktrace.
+[R] → stdin:1:11 Unless conditions should avoid having an `else` block.
+[W] ↗ stdin:9:5 Use `reraise` inside a rescue block to preserve the original stacktrace.
 [W] ↗ Exception modules should be named consistently. It seems your strategy is to have `Error` ....
 ]])
     assert.are.same(2, #result)


### PR DESCRIPTION
373968190b0022be80a6099ecb483cfc2b5fe8af introduces a new parameter `bufnr` that only displays the lint if the item buffer matches `bufnr`. However, parsers that read their input from stdin (`stdin = true`) either do not report a buffer (in which case `item.bufnr` is 0) or incorrectly report their buffer as some variant of `stdin`, `<stdin>`, etc. (when the filename used to be parsed with `%f`).

According to `:help getqflist()`, an item with without a buffer will have `item.bufnr` be 0. 

> Quickfix list entries with a non-existing buffer number are returned
> with "bufnr" set to zero (Note: some functions accept buffer number zero
> for the alternate buffer, you may need to explicitly check for zero).

In this case, we should show the lints. 

Additionally, certain linters (credo, statix) incorrectly parse the filename with `%f` . This has also been fixed.

Fixes #481, #495. Also fixes
- blocklint
- credo
- php
- statix

Fish is out of scope and is actually caused by an [upstream issue](https://github.com/fish-shell/fish-shell/issues/10171).