### PR TITLE
PHP Psalm - fix incorrect diagnostics

### DIFF
--- a/lua/lint/linters/psalm.lua
+++ b/lua/lint/linters/psalm.lua
@@ -19,21 +19,26 @@ return {
       return {}
     end
 
+    local bufnr = vim.api.nvim_get_current_buf()
+    local filename = vim.api.nvim_buf_get_name(bufnr)
+
     local messages = vim.json.decode(output)
     local diagnostics = {}
 
     for _, message in ipairs(messages or {}) do
-      table.insert(diagnostics, {
-        lnum = message.line_from - 1,
-        end_lnum = message.line_to - 1,
-        col = message.column_from - 1,
-        end_col = message.column_to - 1,
-        message = message.message,
-        source = 'psalm',
-        severity = message.severity,
-      })
+      if message.file_path == filename then
+        table.insert(diagnostics, {
+          lnum = message.line_from - 1,
+          end_lnum = message.line_to - 1,
+          col = message.column_from - 1,
+          end_col = message.column_to - 1,
+          message = message.message,
+          source = 'psalm',
+          severity = message.severity,
+        })
+      end
     end
 
-    return diagnostics;
+    return diagnostics
   end,
 }

--- a/lua/lint/linters/psalm.lua
+++ b/lua/lint/linters/psalm.lua
@@ -14,12 +14,11 @@ return {
     '--show-info=true',
     '--no-progress',
   },
-  parser = function(output)
+  parser = function(output, bufnr)
     if output == nil then
       return {}
     end
 
-    local bufnr = vim.api.nvim_get_current_buf()
     local filename = vim.api.nvim_buf_get_name(bufnr)
 
     local messages = vim.json.decode(output)
@@ -40,5 +39,5 @@ return {
     end
 
     return diagnostics
-  end,
+  end
 }


### PR DESCRIPTION
Using Psalm, I had a strange bug where diagnostics for other files were showing in my buffer.
After some testing, I saw that Psalm is outputting diagnostics for the all project (even with `lint.linters.psalm.append_fname = true` and `lint.linters.psalm.stdin = false`).

I fixed it by checking if the message from Psalm is about the current buffer and only creating diagnostic if it is.
Another fix could be to set the bufnr to to the diagnostic table, but that would involve checking each of the open buffers and it's filename.

I'm pretty new to Neovim, please ignore and close if I'm making no sense and if it's just a config problem on my end.