### PR TITLE
parser:add minimal limit for col & lnum

### DIFF
--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -44,7 +44,7 @@ end
 ---
 ---@param pattern string
 ---@param groups string[]
----@param severity_map? table<string, DiagnosticSeverity>
+---@param severity_map? table<string, vim.diagnostic.Severity>
 ---@param defaults? table
 ---@param opts? {col_offset?: integer, end_col_offset?: integer, lnum_offset?: integer, end_lnum_offset?: integer}
 function M.from_pattern(pattern, groups, severity_map, defaults, opts)
@@ -81,6 +81,8 @@ function M.from_pattern(pattern, groups, severity_map, defaults, opts)
     local end_lnum = captures.end_lnum and (tonumber(captures.end_lnum) - 1) or lnum
     local col = tonumber(captures.col) and (tonumber(captures.col) + col_offset) or 0
     local end_col = tonumber(captures.end_col) and (tonumber(captures.end_col) + end_col_offset) or col
+    col = math.max(col, 0)
+    lnum = math.max(lnum, 0)
     local diagnostic = {
       lnum = assert(lnum, 'diagnostic requires a line number') + lnum_offset,
       end_lnum = end_lnum + end_lnum_offset,


### PR DESCRIPTION
Hello,

The change helps to avoid col and lnum values less than 0.

I faced problems with cppcheck 2.12.0. It can report zero line/column number if a problem is located at the beginning of a file. After applying offsets, the value(s) can be < 0, triggering errors in other places. For example, in trouble.nvim plugin because it can't jump on an invalid source location. The limiting of minimal values helped with the problem.


Here is example of cppcheck report with line/column = 0
```
Checking src/hash.cpp ...
src/hash.cpp:0:0: information: Too many #ifdef configurations - cppcheck only checks 12 of 20 configurations. Use --force to check all configurations. [toomanyconfigs]

^
src/hash.cpp:1:0: information: Include file: <noheader.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]
#include <noheader.h>
```

Here is trouble.nvim error message, because it interprets the issue position as line 0 and column 0.
![image](https://github.com/mfussenegger/nvim-lint/assets/50661022/43e02548-34de-481e-8da3-1ebd86b9a085)

![image](https://github.com/mfussenegger/nvim-lint/assets/50661022/120e6735-2e30-41b5-8eb7-b948c617cee7)

After applying changes, the position becomes valid. Jumping/navigation works fine.
![image_2024-01-04_11-07-54](https://github.com/mfussenegger/nvim-lint/assets/50661022/5445064d-d42f-4935-8e37-747b11233dab)

Please feel free to ask for additional modifications/information.

Thank you