### PR TITLE
Add regal and opa_check linters for rego files

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Other dedicated linters that are built-in are:
 | [Nix][nix]                         | `nix`                  |
 | [npm-groovy-lint][npm-groovy-lint] | `npm-groovy-lint`      |
 | [oelint-adv][oelint-adv]           | `oelint-adv`           |
+| [opa_check][opa_check]             | `opa_check`            |
 | [perlcritic][perlcritic]           | `perlcritic`           |
 | [perlimports][perlimports]         | `perlimports`          |
 | [php][php]                         | `php`                  |
@@ -476,3 +477,4 @@ busted tests/
 [typos]: https://github.com/crate-ci/typos
 [joker]: https://github.com/candid82/joker
 [dash]: http://gondor.apana.org.au/~herbert/dash
+[opa_check]: https://www.openpolicyagent.org/

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Other dedicated linters that are built-in are:
 | [pydocstyle][pydocstyle]           | `pydocstyle`           |
 | [pyproject-flake8][pflake8]        | `pflake8`              |
 | [Pylint][15]                       | `pylint`               |
+| [regal][regal]                     | `regal`                |
 | [Revive][14]                       | `revive`               |
 | [rflint][rflint]                   | `rflint`               |
 | [robocop][robocop]                 | `robocop`              |
@@ -478,3 +479,4 @@ busted tests/
 [joker]: https://github.com/candid82/joker
 [dash]: http://gondor.apana.org.au/~herbert/dash
 [opa_check]: https://www.openpolicyagent.org/
+[regal]: https://github.com/StyraInc/regal

--- a/lua/lint/linters/opa_check.lua
+++ b/lua/lint/linters/opa_check.lua
@@ -1,0 +1,36 @@
+-- https://github.com/open-policy-agent/opa
+return {
+  cmd = "opa",
+  args = { "check", "--strict", "--format", "json" },
+  stdin = false,
+  append_fname = true,
+  stream = "stderr",
+  ignore_exitcode = true,
+  parser = function(output, _)
+    local diagnostics = {}
+
+    if output == "" then
+      return diagnostics
+    end
+
+    local decoded = vim.json.decode(output)
+    if decoded ~= nil then
+      for _, item in ipairs(decoded.errors or {}) do
+        local lnum = item.location.row - 1
+
+        table.insert(diagnostics, {
+          lnum = lnum,
+          end_lnum = lnum,
+          col = item.location.col - 1,
+          end_col = item.location.col,
+          severity = vim.diagnostic.severity.ERROR,
+          source = "opa_check",
+          message = item.message,
+          code = item.code,
+        })
+      end
+    end
+
+    return diagnostics
+  end,
+}

--- a/lua/lint/linters/regal.lua
+++ b/lua/lint/linters/regal.lua
@@ -1,0 +1,43 @@
+-- https://github.com/StyraInc/regal
+
+local severities = {
+  error = vim.diagnostic.severity.ERROR,
+  warning = vim.diagnostic.severity.WARN,
+}
+
+return {
+  cmd = "regal",
+  args = { "lint", "--format", "json" },
+  stdin = false,
+  append_fname = true,
+  stream = "stdout",
+  ignore_exitcode = true,
+  parser = function(output, _)
+    local diagnostics = {}
+
+    if output == "" then
+      return diagnostics
+    end
+
+    local decoded = vim.json.decode(output)
+    if decoded ~= nil then
+      for _, item in ipairs(decoded.violations or {}) do
+        local end_col = item.location.text ~= nil and item.location.text:len() + 1 or item.location.col
+        local lnum = math.max(item.location.row - 1, 0)
+
+        table.insert(diagnostics, {
+          lnum = lnum,
+          end_lnum = lnum,
+          col = math.max(item.location.col - 1, 0),
+          end_col = end_col,
+          severity = severities[item.level] or severities.error,
+          source = "[regal] " .. item.category,
+          message = item.description,
+          code = item.title,
+        })
+      end
+    end
+
+    return diagnostics
+  end,
+}


### PR DESCRIPTION
Regal recommends users to run `opa check --strict` alongside it (regal will only take effect when `opa check` passes), so I think it's fine including both of them in the same PR here.

Ref: https://docs.styra.com/regal#opa-check-and-strict-mode