### PR TITLE
feat: add salt-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Other dedicated linters that are built-in are:
 | [Ruby][ruby]                       | `ruby`                 |
 | [RuboCop][rubocop]                 | `rubocop`              |
 | [Ruff][ruff]                       | `ruff`                 |
+| [salt-lint][salt-lint]             | `saltlint`             |
 | [Selene][31]                       | `selene`               |
 | [ShellCheck][10]                   | `shellcheck`           |
 | [snyk][snyk]                       | `snyk_iac`             |
@@ -478,3 +479,4 @@ busted tests/
 [typos]: https://github.com/crate-ci/typos
 [joker]: https://github.com/candid82/joker
 [dash]: http://gondor.apana.org.au/~herbert/dash
+[salt-lint]: https://github.com/warpnet/salt-lint

--- a/lua/lint/linters/saltlint.lua
+++ b/lua/lint/linters/saltlint.lua
@@ -1,0 +1,28 @@
+local severities = {
+  HIGH = vim.diagnostic.severity.ERROR,
+  LOW = vim.diagnostic.severity.WARN,
+  INFO = vim.diagnostic.severity.INFO,
+}
+
+return {
+  cmd = "salt-lint",
+  stdin = true,
+  args = { "--json" },
+  stream = "stdout",
+  ignore_exitcode = true,
+  parser = function(output)
+    local decoded = vim.json.decode(output)
+    local diagnostics = {}
+    for _, item in ipairs(decoded or {}) do
+      table.insert(diagnostics, {
+        lnum = item.linenumber - 1,
+        col = 1,
+        severity = severities[item.severity] or vim.diagnostic.severity.WARN,
+        message = item.message,
+        source = "salt-lint",
+        code = item.id,
+      })
+    end
+    return diagnostics
+  end,
+}

--- a/tests/saltlint_spec.lua
+++ b/tests/saltlint_spec.lua
@@ -1,0 +1,84 @@
+describe("linter.saltlint", function()
+  it("can parse the output", function()
+    local parser = require("lint.linters.saltlint").parser
+    local result = parser([[
+      [
+        {
+          "id": "903",
+          "message": "State 'virt.reverted' is deprecated since SaltStack version '2016.3.0'",
+          "filename": "/tmp/tmpybp_b5bk.sls",
+          "linenumber": 3,
+          "line": "  virt.reverted:",
+          "severity": "HIGH"
+        },
+        {
+          "id": "217",
+          "message": "\"requires\" looks like a typo. Did you mean \"require\"?",
+          "filename": "/tmp/tmpybp_b5bk.sls",
+          "linenumber": 9,
+          "line": "    - requires: foo",
+          "severity": "LOW"
+        },
+        {
+          "id": "201",
+          "message": "Trailing whitespace",
+          "filename": "/tmp/tmpybp_b5bk.sls",
+          "linenumber": 12,
+          "line": "  file.create:  ",
+          "severity": "INFO"
+        },
+        {
+          "id": "204",
+          "message": "Lines should be no longer than 160 chars",
+          "filename": "/tmp/tmpybp_b5bk.sls",
+          "linenumber": 17,
+          "line": "    - name: test_long_line_aaa...",
+          "severity": "VERY_LOW"
+        }
+      ]
+    ]])
+
+    -- Count of results
+    assert.are.same(4, #result)
+
+    -- JSON diagnostic with HIGH severity
+    assert.are.same({
+      lnum = 2,
+      col = 1,
+      severity = vim.diagnostic.severity.ERROR,
+      message = "State 'virt.reverted' is deprecated since SaltStack version '2016.3.0'",
+      source = "salt-lint",
+      code = "903",
+    }, result[1])
+
+    -- JSON diagnostic with LOW severity
+    assert.are.same({
+      lnum = 8,
+      col = 1,
+      severity = vim.diagnostic.severity.WARN,
+      message = '"requires" looks like a typo. Did you mean "require"?',
+      source = "salt-lint",
+      code = "217",
+    }, result[2])
+
+    -- JSON diagnostic with INFO severity
+    assert.are.same({
+      lnum = 11,
+      col = 1,
+      severity = vim.diagnostic.severity.INFO,
+      message = "Trailing whitespace",
+      source = "salt-lint",
+      code = "201",
+    }, result[3])
+
+    -- JSON diagnostic with VERY_LOW severity
+    assert.are.same({
+      lnum = 16,
+      col = 1,
+      severity = vim.diagnostic.severity.WARN,
+      message = "Lines should be no longer than 160 chars",
+      source = "salt-lint",
+      code = "204",
+    }, result[4])
+  end)
+end)


### PR DESCRIPTION
PR to add the `salt-lint` linter for Salt / SaltStack, along with tests.
https://github.com/warpnet/salt-lint

The name `saltlint` (without the dash) was chosen to make it a little easier for a user to add args in their config, with something like the following.
```lua
local saltlint = require("lint").linters.saltlint
table.insert(saltlint.args, 1, "-t")
table.insert(saltlint.args, 2, "209")
```

Thanks!

-----------

Notes:
- `salt-lint` is one of the linters supported by [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) ( in [lua/null-ls/builtins/diagnostics/saltlint.lua](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/diagnostics/saltlint.lua) ).
- I also submitted a PR to get `salt-lint` added to the mason registry (https://github.com/mason-org/mason-registry/pull/4078).