### PR TITLE
biome: use local biome from node_modules if present

### DIFF
--- a/lua/lint/linters/biomejs.lua
+++ b/lua/lint/linters/biomejs.lua
@@ -26,9 +26,13 @@
 --
 --    6 │ ····if·(opt·===·true)·{
 --      │
+local binary_name = "biome"
 
 return {
-  cmd = "biome",
+  cmd = function()
+    local local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+    return vim.loop.fs_stat(local_binary) and local_binary or binary_name
+  end,
   args = { "lint" },
   stdin = false,
   ignore_exitcode = true,


### PR DESCRIPTION
This PR is to adjust `biomejs.lua` linter interface to use local `biome` if it is installed in `node_modules`.
This is to match the behavior from the `eslint` and `eslint_d` linter interfaces.