### PR TITLE
fix: normalize paths before comparing equality

### DIFF
--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -69,7 +69,9 @@ function M.from_pattern(pattern, groups, severity_map, defaults, opts)
       else
         path = vim.fn.simplify(linter_cwd .. '/' .. captures.file)
       end
-      if path ~= buffer_path then
+      local normalized_path = vim.fs.normalize(path)
+      local normalized_buffer_path = vim.fs.normalize(buffer_path)
+      if normalized_path ~= normalized_buffer_path then
         return nil
       end
     end


### PR DESCRIPTION
Fix consistency issues on Windows when some linters use a single backslash, some use a double (escaped) backslash, and some still use a forward slash.

This fix is confirmed to fix issues with Mypy on Windows, and it probably affects other linters as well.

Fixes #480.