### PR TITLE
Add Vala linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Other dedicated linters that are built-in are:
 | [Solhint][solhint]                 | `solhint`              |
 | [typos][typos]                     | `typos`                |
 | [Nagelfar][nagelfar]               | `nagelfar`             |
+| [Vala][vala-lint]                  | `vala_lint`            |
 | [Vale][8]                          | `vale`                 |
 | [Verilator][verilator]             | `verilator`            |
 | [vint][21]                         | `vint`                 |
@@ -486,3 +487,4 @@ busted tests/
 [quick-lint-js]: https://quick-lint-js.com
 [opa_check]: https://www.openpolicyagent.org/
 [regal]: https://github.com/StyraInc/regal
+[vala-lint]: https://github.com/vala-lang/vala-lint

--- a/lua/lint/linters/vala_lint.lua
+++ b/lua/lint/linters/vala_lint.lua
@@ -1,0 +1,40 @@
+local severity = {
+  ["warn"] = vim.diagnostic.severity.WARN,
+  ["error"] = vim.diagnostic.severity.ERROR,
+}
+
+return {
+  cmd = "io.elementary.vala-lint",
+  stdin = false,
+  append_fname = true,
+  args = {
+    "--json-output",
+    "--print-end",
+  },
+  ignore_exitcode = true,
+  parser = function(output, bufnr)
+    local diagnostics = {}
+    local ok, decoded = pcall(vim.json.decode, output)
+    if not ok then
+      return diagnostics
+    end
+    local fpath = vim.api.nvim_buf_get_name(bufnr)
+    for _, mistake in ipairs(decoded and decoded.mistakes or {}) do
+      -- Only show results of the current file in the buffer
+      if mistake.filename == fpath then
+        local err = {
+          source = "vala-lint",
+          message = mistake.message,
+          col = mistake.column,
+          end_col = mistake.endColumn,
+          lnum = mistake.line - 1,
+          end_lnum = mistake.endLine - 1,
+          code = mistake.ruleId,
+          severity = severity[mistake.level],
+        }
+        table.insert(diagnostics, err)
+      end
+    end
+    return diagnostics
+  end,
+}


### PR DESCRIPTION
Hi,

I implemented the Vala linter.
I got a copy of [tfsec linter](https://github.com/mfussenegger/nvim-lint/blob/master/lua/lint/linters/tfsec.lua) and changed it to make it compatible for Vala lang.

Sample vala-lint output:
```bash
$ io.elementary.vala-lint -j -e sample.vala | jq .
{
  "mistakes": [
    {
      "filename": "sample.vala",
      "line": 5,
      "column": 21,
      "endLine": 5,
      "endColumn": 23,
      "level": "error",
      "message": "Expected a single space",
      "ruleId": "double-spaces"
    },
    {
      "filename": "sample.vala",
      "line": 21,
      "column": 25,
      "endLine": 21,
      "endColumn": 27,
      "level": "error",
      "message": "Expected a single space",
      "ruleId": "double-spaces"
    }
  ]
}
```

Result:
![image](https://github.com/mfussenegger/nvim-lint/assets/1261448/fd91afe3-73a2-4992-b830-01c0bcf5ef7b)

