### PR TITLE
fix: golangci-lint respect cwd

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -18,7 +18,7 @@ return {
   },
   stream = 'stdout',
   ignore_exitcode = true,
-  parser = function(output, bufnr)
+  parser = function(output, bufnr, cwd)
     if output == '' then
       return {}
     end
@@ -30,7 +30,7 @@ return {
     local diagnostics = {}
     for _, item in ipairs(decoded["Issues"]) do
       local curfile = vim.api.nvim_buf_get_name(bufnr)
-      local lintedfile = vim.fn.getcwd() .. "/" .. item.Pos.Filename
+      local lintedfile = cwd .. "/" .. item.Pos.Filename
       if curfile == lintedfile then
         -- only publish if those are the current file diagnostics
         local sv = severities[item.Severity] or severities.warning


### PR DESCRIPTION
This PR allows `golangcilint` to use provided `cwd` instead of `vim.fn.getcwd()` using functionality that was added in https://github.com/mfussenegger/nvim-lint/pull/358

It might be helpful for a monorepo with multiple languages.

```bash
project-root
├── .golangci.yaml
├── client
│   └── lxc.py
├── agent
│   ├── go.mod
│   └── cmd
│       └── main.go
└── core
    ├── go.mod
    └── main.go
```

If my `vim.fn.getcwd()` will be `project-root` I won't be able to run `golangcilint` since it will fail to find any Go modules
```
ERRO [linters_context] typechecking error: pattern ./...: directory prefix . does not contain main module or its selected dependencies
```

However, with some auto commands I can search for `go.mod` among ancestors that are related to my buffer path:
```lua
vim.api.nvim_create_autocmd({ 'BufEnter' }, {
  pattern = { '*.go' },
  callback = function()
    local lsputil = require('lspconfig.util')
    local cwd = lsputil.root_pattern("go.mod")(vim.fn.expand('%:p'))
    local config = lsputil.root_pattern(".golangci.yaml")(vim.fn.expand('%:p'))
    local golangcilint = require('lint.linters.golangcilint')
    golangcilint.args = {
      'run',
      '--out-format',
      'json',
      '--timeout',
      '5m',
    }
    if config ~= nil then
      config = config .. '/.golangci.yaml'
      table.insert(golangcilint.args, '--config')
      table.insert(golangcilint.args, config)
    end
    golangcilint.cwd = cwd
  end,
})
```

