### PR TITLE
fix: Check if build directory exists for cppcheck 

### DIFF
--- a/lua/lint/linters/cppcheck.lua
+++ b/lua/lint/linters/cppcheck.lua
@@ -23,7 +23,13 @@ return {
     end,
     "--inline-suppr",
     "--quiet",
-    "--cppcheck-build-dir=build",
+    function()
+      if vim.fn.isdirectory("build") == 1 then
+        return "--cppcheck-build-dir=build"
+      else
+        return ""
+      end
+    end,
     "--template={file}:{line}:{column}: [{id}] {severity}: {message}",
   },
   stream = "stderr",


### PR DESCRIPTION
This is a fix of #492 for cppcheck. 
Now we check if build directory exists before passing the argument to cppcheck. 