### PR TITLE
rubocop: Add --server and --stdin options to rubocop

### DIFF
--- a/lua/lint/linters/rubocop.lua
+++ b/lua/lint/linters/rubocop.lua
@@ -9,8 +9,15 @@ local severity_map = {
 
 return {
   cmd = 'rubocop',
-  stdin = false,
-  args = {'--format', 'json', '--force-exclusion'},
+  stdin = true,
+  args = {
+    '--format',
+    'json',
+    '--force-exclusion',
+    '--server',
+    '--stdin',
+    function() return vim.api.nvim_buf_get_name(0) end,
+  },
   ignore_exitcode = true,
   parser = function(output)
     local diagnostics = {}


### PR DESCRIPTION
Add --stdin and --server option to rubocop

[Rubocop Server Mode](https://docs.rubocop.org/rubocop/usage/server.html) launchs deamon process and speed up launch time of rubocop.