### PR TITLE
fix(typos): line_num is not always returned

### DIFF
--- a/lua/lint/linters/typos.lua
+++ b/lua/lint/linters/typos.lua
@@ -28,7 +28,7 @@ return {
     for json in string.gmatch(output, "[%S]+") do
       local item = vim.json.decode(json)
 
-      if item ~= nil then
+      if item ~= nil and item.line_num ~= nil then
         local line_num = item.line_num - 1
         local corrections = table.concat(item.corrections, " or ")
 


### PR DESCRIPTION
At least with recent `typos` (I have 1.18.1) the `line_num` is not returned when the typo is discovered on the first line of the document. Only `byte_offset` is returned. This causes a *parser error* to appear at the top of the file in vtext.