### PR TITLE
feat: add spectral

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Other dedicated linters that are built-in are:
 | [ShellCheck][10]                       | `shellcheck`           |
 | [snyk][snyk]                           | `snyk_iac`             |
 | [Solhint][solhint]                     | `solhint`              |
+| [Spectral][spectral]                   | `spectral`             |
 | [sqlfluff][sqlfluff]                   | `sqlfluff`             |
 | [standardjs][standardjs]               | `standardjs`           |
 | [StandardRB][27]                       | `standardrb`           |
@@ -511,6 +512,7 @@ busted tests/
 [dotenv-linter]: https://dotenv-linter.github.io/
 [puppet-lint]: https://github.com/puppetlabs/puppet-lint
 [snyk]: https://github.com/snyk/cli
+[spectral]: https://github.com/stoplightio/spectral
 [gitlint]: https://github.com/jorisroovers/gitlint
 [pflake8]: https://github.com/csachs/pyproject-flake8
 [fish]: https://github.com/fish-shell/fish-shell

--- a/lua/lint/linters/spectral.lua
+++ b/lua/lint/linters/spectral.lua
@@ -1,0 +1,50 @@
+local severities = {
+  vim.diagnostic.severity.HINT,
+  vim.diagnostic.severity.INFO,
+  vim.diagnostic.severity.WARN,
+  vim.diagnostic.severity.ERROR,
+}
+
+return function(ruleset)
+  return {
+    cmd = 'spectral',
+    stdin = false,
+    append_fname = true,
+    args = { "lint", "-r", ruleset, "-f", "json", },
+    stream = "stdout",
+    ignore_exitcode = true,
+    parser = function(output, _)
+      local items = {}
+
+      if output == '' then
+        return items
+      end
+
+      local decoded = vim.json.decode(output) or {}
+      local bufpath = vim.fn.expand('%:p')
+
+      -- prevent warning on files that are not OpenAPI specs
+      if decoded[1].code == "unrecognized-format" then
+        return items
+      end
+
+      for _, diag in ipairs(decoded) do
+        vim.print(diag.severity)
+        if diag.source == bufpath then
+          table.insert(items, {
+            source = "spectral",
+            severity = severities[diag.severity + 1],
+            code = diag.code,
+            message = diag.message,
+            lnum = diag.range.start.line + 1,
+            end_lnum = diag.range["end"].line + 1,
+            col = diag.range.start.character + 1,
+            end_col = diag.range["end"].character + 1,
+          })
+        end
+      end
+
+      return items
+    end,
+  }
+end

--- a/lua/lint/linters/spectral.lua
+++ b/lua/lint/linters/spectral.lua
@@ -22,12 +22,7 @@ return {
       return {}
     end
 
-    -- attempt to decode linter result
-    local success, result = pcall(vim.json.decode, output)
-    if not success then
-      vim.notify("Spectral exited with an error:\n" .. output, vim.log.levels.ERROR)
-      return {}
-    end
+    local result = vim.json.decode(output)
 
     -- prevent warning on yaml files without supported schema
     if result[1].code == "unrecognized-format" then


### PR DESCRIPTION
Hi @mfussenegger,

thanks for this great plugin.  
I would like to add the [Spectral](https://docs.stoplight.io/docs/spectral/674b27b261c3c-overview) linter for OpenAPI specifications.

There is a slight problem in that the linter takes a *required* parameter `--ruleset` that takes either a file path or a URL.  
Without this parameter, the linter will error out.

I have implemented it in a way, where the user would have to do something like this, which is a bit awkward 😄
```lua
require('lint').linters.spectral = require('lint').linters.spectral("path/to/ruleset")
```

Another approach would be to not specify the ruleset parameter by default, let the linter error and let the user figure out how to override the linters `args`. This is also pretty inconvenient.

I would appreciate your feedback on which of the options you would prefer, or if you maybe have a better idea.  
I could also contribute some better documentation so users would know how to configure this specific linter.

If it's not a good fit for the project because of this constraint, I obviously understand.