### PR TITLE
feat: Add message symbol to pylint errors

### DIFF
--- a/lua/lint/linters/pylint.lua
+++ b/lua/lint/linters/pylint.lua
@@ -30,7 +30,7 @@ return {
           end_lnum = item.line - 1,
           end_col = end_column,
           severity = assert(severities[item.type], 'missing mapping for severity ' .. item.type),
-          message = item.message,
+          message = item.message .. " (" .. item.symbol .. ")",
           code = item['message-id'],
           user_data = {
             lsp = {

--- a/tests/pylint_spec.lua
+++ b/tests/pylint_spec.lua
@@ -57,7 +57,7 @@ describe('linter.pylint', function()
 
     local expected_1 = {
       source = 'pylint',
-      message = 'Bad indentation. Found 2 spaces, expected 4',
+      message = 'Bad indentation. Found 2 spaces, expected 4 (bad-indentation)',
       lnum = 3,
       col = 0,
       end_lnum = 3,
@@ -75,7 +75,7 @@ describe('linter.pylint', function()
 
     local expected_2 = {
       source = 'pylint',
-      message = 'Missing module docstring',
+      message = 'Missing module docstring (missing-module-docstring)',
       lnum = 0,
       col = 0,
       end_lnum = 0,
@@ -93,7 +93,7 @@ describe('linter.pylint', function()
 
     local expected_3 = {
       source = 'pylint',
-      message = 'Redundant comparison - 1 == 1',
+      message = 'Redundant comparison - 1 == 1 (comparison-with-itself)',
       lnum = 2,
       col = 3,
       end_lnum = 2,
@@ -111,7 +111,7 @@ describe('linter.pylint', function()
 
     local expected_4 = {
       source = 'pylint',
-      message = "Unused variable 'test'",
+      message = "Unused variable 'test' (unused-variable)",
       lnum = 4,
       col = 4,
       end_lnum = 4,


### PR DESCRIPTION
![image](https://github.com/mfussenegger/nvim-lint/assets/12065867/84619cc8-9fa8-4b66-9b6f-844d01f54f4b)

```
        "symbol": "subprocess-popen-preexec-fn",
        "message": "Using preexec_fn keyword which may be unsafe in the presence of threads",
        "message-id": "W1509"
```

Use the message symbol to know which rule it references, the id is hard to understand.