### PR TITLE
feat: add markuplint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Other dedicated linters that are built-in are:
 | [Languagetool][5]                  | `languagetool`         |
 | [luacheck][19]                     | `luacheck`             |
 | [markdownlint][26]                 | `markdownlint`         |
-| [markuplint][markuplint]                   | `markuplint`           |
+| [markuplint][markuplint]           | `markuplint`           |
 | [mlint][34]                        | `mlint`                |
 | [Mypy][11]                         | `mypy`                 |
 | [Nix][nix]                         | `nix`                  |

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Other dedicated linters that are built-in are:
 | [Languagetool][5]                  | `languagetool`         |
 | [luacheck][19]                     | `luacheck`             |
 | [markdownlint][26]                 | `markdownlint`         |
+| [markuplint][markuplint]                   | `markuplint`           |
 | [mlint][34]                        | `mlint`                |
 | [Mypy][11]                         | `mypy`                 |
 | [Nix][nix]                         | `nix`                  |
@@ -497,3 +498,4 @@ busted tests/
 [vala-lint]: https://github.com/vala-lang/vala-lint
 [systemdlint]: https://github.com/priv-kweihmann/systemdlint
 [htmlhint]: https://htmlhint.com/
+[markuplint]: https://markuplint.dev/

--- a/lua/lint/linters/markuplint.lua
+++ b/lua/lint/linters/markuplint.lua
@@ -1,5 +1,10 @@
 local binary_name = "markuplint"
 
+local severity_map = {
+  error = vim.diagnostic.severity.ERROR,
+  warning = vim.diagnostic.severity.WARN,
+}
+
 return {
   cmd = function()
     local local_binary = vim.fn.fnamemodify("./node_modules/.bin/" .. binary_name, ":p")
@@ -34,7 +39,7 @@ return {
         col = result.col and result.col - 1 or 0,
         message = result.message,
         code = result.ruleId,
-        severity = result.severity,
+        severity = severity_map[result.severity] or vim.diagnostic.severity.ERROR,
         source = "markuplint",
       })
     end

--- a/lua/lint/linters/markuplint.lua
+++ b/lua/lint/linters/markuplint.lua
@@ -14,7 +14,7 @@ return {
   stdin = false,
   stream = "stdout",
   ignore_exitcode = true,
-  parser = function(output, bufnr)
+  parser = function(output)
     if vim.trim(output) == "" then
       return {}
     end

--- a/lua/lint/linters/markuplint.lua
+++ b/lua/lint/linters/markuplint.lua
@@ -1,0 +1,43 @@
+local binary_name = "markuplint"
+
+return {
+  cmd = function()
+    local local_binary = vim.fn.fnamemodify("./node_modules/.bin/" .. binary_name, ":p")
+    return vim.loop.fs_stat(local_binary) and local_binary or binary_name
+  end,
+  args = { "--format", "JSON" },
+  stdin = false,
+  stream = "stdout",
+  ignore_exitcode = true,
+  parser = function(output, bufnr)
+    if vim.trim(output) == "" then
+      return {}
+    end
+
+    local decode_opts = { luanil = { object = true, array = true } }
+    local ok, data = pcall(vim.json.decode, output, decode_opts)
+    if not ok then
+      return {
+        {
+          bufnr = bufnr,
+          lnum = 0,
+          col = 0,
+          message = "Could not parse markuplint output due to: " .. data .. "\noutput: " .. output,
+        },
+      }
+    end
+
+    local diagnostics = {}
+    for _, result in ipairs(data or {}) do
+      table.insert(diagnostics, {
+        lnum = result.line and result.line - 1 or 0,
+        col = result.col and result.col - 1 or 0,
+        message = result.message,
+        code = result.ruleId,
+        severity = result.severity,
+        source = "markuplint",
+      })
+    end
+    return diagnostics
+  end,
+}

--- a/lua/lint/linters/markuplint.lua
+++ b/lua/lint/linters/markuplint.lua
@@ -20,17 +20,7 @@ return {
     end
 
     local decode_opts = { luanil = { object = true, array = true } }
-    local ok, data = pcall(vim.json.decode, output, decode_opts)
-    if not ok then
-      return {
-        {
-          bufnr = bufnr,
-          lnum = 0,
-          col = 0,
-          message = "Could not parse markuplint output due to: " .. data .. "\noutput: " .. output,
-        },
-      }
-    end
+    local data = vim.json.decode(output, decode_opts)
 
     local diagnostics = {}
     for _, result in ipairs(data or {}) do

--- a/tests/markuplint_spec.lua
+++ b/tests/markuplint_spec.lua
@@ -1,0 +1,50 @@
+describe("linter.markuplint", function()
+  it("can parse the output", function()
+    local parser = require("lint.linters.markuplint").parser
+    local output = [[
+[
+  {
+    "severity": "error",
+    "message": "The value of the \"id\" attribute is duplicated",
+    "line": 12,
+    "col": 8,
+    "raw": "id=\"root\"",
+    "ruleId": "id-duplication",
+    "filePath": "/test/index.html"
+  },
+  {
+    "severity": "warning",
+    "message": "Require the \"h1\" element",
+    "line": 1,
+    "col": 1,
+    "raw": "<",
+    "ruleId": "required-h1",
+    "filePath": "/test/index.html"
+  }
+]
+]]
+
+    local result = parser(output, vim.api.nvim_get_current_buf())
+    assert.are.same(2, #result)
+
+    local expected = {
+      lnum = 11,
+      col = 7,
+      message = 'The value of the "id" attribute is duplicated',
+      severity = vim.diagnostic.severity.ERROR,
+      code = "id-duplication",
+      source = "markuplint",
+    }
+    assert.are.same(expected, result[1])
+
+    expected = {
+      lnum = 0,
+      col = 0,
+      message = 'Require the "h1" element',
+      severity = vim.diagnostic.severity.WARN,
+      code = "required-h1",
+      source = "markuplint",
+    }
+    assert.are.same(expected, result[2])
+  end)
+end)

--- a/tests/markuplint_spec.lua
+++ b/tests/markuplint_spec.lua
@@ -24,7 +24,7 @@ describe("linter.markuplint", function()
 ]
 ]]
 
-    local result = parser(output, vim.api.nvim_get_current_buf())
+    local result = parser(output)
     assert.are.same(2, #result)
 
     local expected = {


### PR DESCRIPTION
# Changes

1. Add `markuplint` support.
   - homepage: https://markuplint.dev/
   - CLI reference: https://markuplint.dev/docs/guides/cli
2. Update readme.

# Screenshot

![Screenshot 2024-02-24 at 0 02 48](https://github.com/mfussenegger/nvim-lint/assets/6694722/f18b23b4-7714-427d-853a-21bfa8e92c26)