### PR TITLE
Fix off-by-one column in clj-kondo

### DIFF
--- a/lua/lint/linters/clj-kondo.lua
+++ b/lua/lint/linters/clj-kondo.lua
@@ -23,9 +23,9 @@ return {
     for _, finding in pairs(findings or {}) do
       table.insert(diagnostics, {
         lnum = finding.row - 1,
-        col = finding.col,
+        col = finding.col - 1,
         end_lnum = finding.row - 1,
-        end_col = finding.col,
+        end_col = finding.col - 1,
         severity = assert(severities[finding.level], 'missing mapping for severity ' .. finding.level),
         message = finding.message,
       })


### PR DESCRIPTION
 <img width="563" alt="image" src="https://github.com/mfussenegger/nvim-lint/assets/9650060/f46e4775-429f-4561-bcf5-d2ff7ff5452a">

Diagnostics appear one character too far to the right.