### PR TITLE
vim.uv requires nvim 0.10 or higher, use vim.loop instead

### DIFF
--- a/lua/lint/linters/perlcritic.lua
+++ b/lua/lint/linters/perlcritic.lua
@@ -11,7 +11,7 @@ local severity_map = {
 local find_conf = function()
   local conf = vim.fs.find('.perlcriticrc', {
     upward = true,
-    stop = vim.fs.dirname(vim.uv.os_homedir()),
+    stop = vim.fs.dirname(vim.loop.os_homedir()),
     path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),
   })
   return conf[1] or ''


### PR DESCRIPTION
Small change to maintain compatability with older versions