### PR TITLE
feat: add configuration of global (`*`) and fallback (`_`) linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ git clone \
 Configure the linters you want to run per file type. For example:
 
 ```lua
-require('lint').linters_by_ft = {
-  markdown = {'vale',}
+require("lint").linters_by_ft = {
+  markdown = { "vale" },
+  ["*"] = { "codespell" }, -- global filetype to run linter on all filetypes
+  ["_"] = { "write-good" }, -- fallback filetype to run linter when no filetype specific linter is available
 }
 ```
 

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -79,22 +79,25 @@ local function read_output(cwd, bufnr, parser, publish_fn)
   end
 end
 
-
-function M._resolve_linter_by_ft(ft)
-  local names = M.linters_by_ft[ft]
-  if names then
-    return names
-  end
-  local dedup_linters = {}
-  local filetypes = vim.split(ft, '.', { plain = true })
-  for _, ft_ in pairs(filetypes) do
-    local linters = M.linters_by_ft[ft_]
-    if linters then
-      for _, linter in ipairs(linters) do
-        dedup_linters[linter] = true
-      end
+local function insert_ft_linters(dict, ft)
+  local linters = M.linters_by_ft[ft]
+  if linters then
+    for _, string in ipairs(linters) do
+      dict[string] = true
     end
   end
+end
+
+function M._resolve_linter_by_ft(ft)
+  local dedup_linters = {}
+  local filetypes = M.linters_by_ft[ft] and { ft } or vim.split(ft, '.', { plain = true })
+  for _, ft_ in pairs(filetypes) do
+    insert_ft_linters(dedup_linters, ft_)
+  end
+  if not next(dedup_linters) then -- insert fallback linters
+    insert_ft_linters(dedup_linters, '_')
+  end
+  insert_ft_linters(dedup_linters, '*') -- insert global linters
   return vim.tbl_keys(dedup_linters)
 end
 

--- a/tests/lint_spec.lua
+++ b/tests/lint_spec.lua
@@ -24,6 +24,30 @@ describe('lint', function()
     table.sort(names, function(x, y) return x < y end)
     assert.are.same(expected, names)
   end)
+  it('insert global linters', function()
+    lint.linters_by_ft = {
+      ansible = {'ansible-lint','yamllint'},
+      yaml = {'yamllint'},
+      ["*"] = {'codespell'},
+      ["_"] = {'write-good'}
+    }
+    local names = lint._resolve_linter_by_ft('ansible.yaml')
+    local expected = {'ansible-lint', 'codespell', 'yamllint'}
+    table.sort(names, function(x, y) return x < y end)
+    assert.are.same(expected, names)
+  end)
+  it('correctly fallback on linters', function()
+    lint.linters_by_ft = {
+      ansible = {'ansible-lint','yamllint'},
+      yaml = {'yamllint'},
+      ["*"] = {'codespell'},
+      ["_"] = {'write-good'}
+    }
+    local names = lint._resolve_linter_by_ft('lua')
+    local expected = {'codespell', 'write-good'}
+    table.sort(names, function(x, y) return x < y end)
+    assert.are.same(expected, names)
+  end)
 
 
   it("get_running returns running linter", function()


### PR DESCRIPTION
This adds the ability to provide both global and fallback linters which play nicely with the filetype resolution. I also added a couple tests to make sure they get applied correctly.