### PR TITLE
feat(parser): adds option to not split lines

### DIFF
--- a/lua/lint/linters/nix.lua
+++ b/lua/lint/linters/nix.lua
@@ -1,4 +1,4 @@
-local pattern = '^(%w+): (.+) at .+:(%d+):(%d+)$'
+local pattern = '(%w+): (.+)\n%s*at .+:(%d+):(%d+)'
 local groups = { 'severity', 'message', 'lnum', 'col' }
 local severity_map = { error = vim.diagnostic.severity.ERROR }
 
@@ -14,5 +14,7 @@ return {
   parser = require('lint.parser').from_pattern(pattern, groups, severity_map, {
     ['source'] = 'nix',
     ['severity'] = vim.diagnostic.severity.WARN,
+  }, {
+    no_split = true,
   })
 }

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -50,7 +50,7 @@ local normalize = (vim.fs ~= nil and vim.fs.normalize ~= nil)
 ---@param groups string[]
 ---@param severity_map? table<string, vim.diagnostic.Severity>
 ---@param defaults? table
----@param opts? {col_offset?: integer, end_col_offset?: integer, lnum_offset?: integer, end_lnum_offset?: integer}
+---@param opts? {col_offset?: integer, end_col_offset?: integer, lnum_offset?: integer, end_lnum_offset?: integer, no_split?: boolean}
 function M.from_pattern(pattern, groups, severity_map, defaults, opts)
   defaults = defaults or {}
   severity_map = severity_map or {}
@@ -112,8 +112,14 @@ function M.from_pattern(pattern, groups, severity_map, defaults, opts)
     end
     local result = {}
     local buffer_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":p")
-    for _, line in ipairs(vim.fn.split(output, '\n')) do
-      local diagnostic = match(linter_cwd, buffer_path, line)
+    local parts
+    if opts.no_split then
+      parts = {output}
+    else
+      parts = vim.fn.split(output, '\n')
+    end
+    for _, part in ipairs(parts) do
+      local diagnostic = match(linter_cwd, buffer_path, part)
       if diagnostic then
         table.insert(result, diagnostic)
       end


### PR DESCRIPTION
I don't know if this is the best solution but I was having issues with the `nix` linter. The reason seems to be that I get errors such as:
```
error: undefined variable 'pkg'
       at /home/axel/.config/home-manager/home.nix:23:5:
           22|     # # "Hello, world!" when run.
           23|     pkg.hello
             |     ^
           24|     pkgs.neovim
```
where the pattern (`(%w+): (.+)\n%s*at .+:(%d+):(%d+)`) looks for a match which is actually in the above two lines. Since lines from stdout/stderr are passed line by line to the pattern we don't get any match.

This adds an option to `from_pattern` to not split the lines before passing to the pattern. This can of course then only give a single error at a time. But at least for `nix` this seems to be the case anyway?

Happy for some suggestions of how to handle this better.