### PR TITLE
feat: add default severity option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ example on the `InsertLeave` or `TextChanged` events.
 If you want to customize how the diagnostics are displayed, read `:help
 vim.diagnostic.config`.
 
+You can set the default diagnostic severity used for some linters
+(default is `INFO`)
+
+```lua
+require('lint').default_severity = vim.diagnostic.severity.HINT
+```
 
 ## Available Linters
 

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -59,6 +59,8 @@ M.linters_by_ft = {
   terraform = {'tflint'},
 }
 
+M.default_severity = vim.diagnostic.severity.INFO
+
 local namespaces = setmetatable({}, {
   __index = function(tbl, key)
     local ns = api.nvim_create_namespace(key)

--- a/lua/lint/linters/ansible_lint.lua
+++ b/lua/lint/linters/ansible_lint.lua
@@ -4,6 +4,6 @@ return {
   ignore_exitcode = true,
   parser = require('lint.parser').from_errorformat('%f:%l: %m', {
     source = 'ansible-lint',
-    severity = vim.diagnostic.severity.INFO
+    severity = require('lint').default_severity,
   })
 }

--- a/lua/lint/linters/blocklint.lua
+++ b/lua/lint/linters/blocklint.lua
@@ -4,6 +4,6 @@ return {
   stdin = true,
   parser = require("lint.parser").from_errorformat("stdin:%l:%c:%k: %m", {
     source = "blocklint",
-    severity = vim.diagnostic.severity.INFO,
+    severity = require('lint').default_severity,
   }),
 }

--- a/lua/lint/linters/codespell.lua
+++ b/lua/lint/linters/codespell.lua
@@ -5,7 +5,7 @@ return {
   ignore_exitcode = true,
   parser = require('lint.parser').from_errorformat(
     '%f:%l:%m',
-    { severity = vim.diagnostic.severity.INFO,
+    { severity = require('lint').default_severity,
       source = 'codespell'}
   )
 }

--- a/lua/lint/linters/cspell.lua
+++ b/lua/lint/linters/cspell.lua
@@ -28,7 +28,7 @@ return {
           end_col = end_col,
           message = message,
           source = 'cspell',
-          severity = vim.diagnostic.severity.INFO
+          severity = require('lint').default_severity,
         }
         table.insert(result, diagnostic)
       end

--- a/lua/lint/linters/editorconfig-checker.lua
+++ b/lua/lint/linters/editorconfig-checker.lua
@@ -10,6 +10,6 @@ return {
     pattern,
     groups,
     nil,
-    { severity = vim.diagnostic.severity.INFO, source = "editorconfig-checker" }
+    { severity = require('lint').default_severity, source = "editorconfig-checker" }
   ),
 }

--- a/lua/lint/linters/perlimports.lua
+++ b/lua/lint/linters/perlimports.lua
@@ -17,7 +17,7 @@ return function()
           col = decoded.location.start.column - 1,
           end_lnum = decoded.location['end'].line - 1,
           end_col = decoded.location['end'].column - 1,
-          severity = vim.diagnostic.severity.INFO,
+          severity = require('lint').default_severity,
           message = decoded.reason,
         })
       end


### PR DESCRIPTION
fix #557

Allows to customize the default diagnostic severity used for certain linters