### PR TITLE
fix(ansible-lint): add --nocolor argument

### DIFF
--- a/lua/lint/linters/ansible_lint.lua
+++ b/lua/lint/linters/ansible_lint.lua
@@ -1,6 +1,6 @@
 return {
   cmd = 'ansible-lint',
-  args = { '-p' },
+  args = { '-p', '--nocolor' },
   ignore_exitcode = true,
   parser = require('lint.parser').from_errorformat('%f:%l: %m', {
     source = 'ansible-lint',


### PR DESCRIPTION
The output of `ansible-lint` was colored (at least on my machine). This lead to the parser failing to parse any diagnostics. By setting the `--nocolor` the diagnostics began to show up properly.

I also checked some other parsers and many of them had colors disabled, so this should probably be the case for `ansible-lint` too.