### PR TITLE
Add ignore_errors option to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ vim.api.nvim_create_autocmd({ "BufWritePost" }, {
     -- for the current filetype
     require("lint").try_lint()
 
+    -- try_lint has an ignore_errors option to ignore command-not-found errors
+    -- require("lint").try_lint(nil, { ignore_errors = true })
+
     -- You can call `try_lint` with a linter name or a list of names to always
     -- run specific linters, independent of the `linters_by_ft` configuration
     require("lint").try_lint("cspell")


### PR DESCRIPTION
People keep asking about the option to ignore ENOENT errors (#454, #569), i was also having the same problem
I think it's a good idea to include it in the README!