### PR TITLE
golangci-lint: fixing stdout of golangci-lint when some output flags …

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -12,6 +12,9 @@ return {
     'run',
     '--out-format',
     'json',
+    '--show-stats=false',
+    '--print-issued-lines=false',
+    '--print-linter-name=false',
     function()
       return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ":h")
     end


### PR DESCRIPTION
If some of the items below are enable on .golangci.yml it will print some things on stdout that will break the nvim-lint parsing
- --show-stats
- --print-issued-lines
- --print-linter-name

ISSUE:
![CleanShot 2024-04-29 at 20 46 05](https://github.com/mfussenegger/nvim-lint/assets/30378044/d6daef7e-c759-49e4-92ab-ada7d8985e15)

SOLUTION:
![CleanShot 2024-04-29 at 20 47 08](https://github.com/mfussenegger/nvim-lint/assets/30378044/d485515b-b23f-4eb3-a664-061d9ba327d6)

RESULT:
![CleanShot 2024-04-29 at 20 50 14](https://github.com/mfussenegger/nvim-lint/assets/30378044/ec2a290e-2dc7-4434-bbaf-b2b61811b389)
