### PR TITLE
Add markdownlint-cli2 for package.json configuration & speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Other dedicated linters that are built-in are:
 | [trivy][trivy]                     | `trivy`                |
 | [zsh][zsh]                         | `zsh`                  |
 | [quick-lint-js][quick-lint-js]     | `quick-lint-js`        |
+| [markdownlint-cli2][markdownlint-cli2] | `markdownlint-cli2`    |
 
 ## Custom Linters
 
@@ -521,5 +522,6 @@ busted tests/
 [systemdlint]: https://github.com/priv-kweihmann/systemdlint
 [htmlhint]: https://htmlhint.com/
 [markuplint]: https://markuplint.dev/
+[markdownlint-cli2]: https://github.com/DavidAnson/markdownlint-cli2
 [swiftlint]: https://github.com/realm/SwiftLint
 [tflint]: https://github.com/terraform-linters/tflint

--- a/lua/lint/linters/markdownlint-cli2.lua
+++ b/lua/lint/linters/markdownlint-cli2.lua
@@ -1,0 +1,10 @@
+local efm = "%f:%l:%c %m,%f:%l %m"
+return {
+  cmd = "markdownlint-cli2",
+  ignore_exitcode = true,
+  stream = "stderr",
+  parser = require("lint.parser").from_errorformat(efm, {
+    source = "markdownlint",
+    severity = vim.diagnostic.severity.WARN,
+  }),
+}


### PR DESCRIPTION
Hi there,

I figured markdownlint doesnt provide a proper and fast CLI for linting markdown files, more importantly in my neovim projects I can't put my linter configurations to package.json with other tools: `markdownlint` or `markdownlint-cli`. This is the only one that provides this option.

I don't know whether declaring the linter here triggers mason download of the said package `markdownlint-cli2`, however I tested that this contribution works when I have `markdownlint-cli2` installed. Hope this is sufficient for adding this linter to `nvim-lint`.