### PR TITLE
trivy: Handle nil result misconfigurations

### DIFF
--- a/lua/lint/linters/trivy.lua
+++ b/lua/lint/linters/trivy.lua
@@ -20,7 +20,7 @@ return {
     local fpath = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t")
     for _, result in ipairs(decoded and decoded.Results or {}) do
       if result.Target == fpath then
-        for _, misconfig in ipairs(result.Misconfigurations) do
+        for _, misconfig in ipairs(result.Misconfigurations or {}) do
           local err = {
             source = "trivy",
             message = string.format("%s %s", misconfig.Title, misconfig.Description),


### PR DESCRIPTION
`result.Misconfigurations` can be a nil value.
I encountered this by explicitly ignoring two Terraform misconfiguration rules.

In the example below, there are two #trivy:ignore comments.
Having two ignore comments results in `result.Misconfigurations` being nil. 

```
#trivy:ignore:AVD-AWS-0089
resource "aws_s3_bucket" "this" {
  bucket = "some-bucket-name"
}

#trivy:ignore:AVD-AWS-0132
resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
  bucket = aws_s3_bucket.this.id

  rule {
    apply_server_side_encryption_by_default {
      sse_algorithm = "AES256"
    }
  }
}

To solve this, I followed the pattern from two lines above where possible falsy value was pair with an "or {}".