### PR TITLE
Fix cppcheck default config

### DIFF
--- a/lua/lint/linters/cppcheck.lua
+++ b/lua/lint/linters/cppcheck.lua
@@ -27,7 +27,7 @@ return {
       if vim.fn.isdirectory("build") == 1 then
         return "--cppcheck-build-dir=build"
       else
-        return ""
+        return nil
       end
     end,
     "--template={file}:{line}:{column}: [{id}] {severity}: {message}",


### PR DESCRIPTION
The function which returns the build directory might return an empty string, which is interpreted by cppcheck as a filename.

This errors if the user specifies the `--project=` argument, because it requires not to pass any file argument.