### PR TITLE
fix(eslint): warn user of no config file instead of showing in buffer

### DIFF
--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -20,11 +20,16 @@ return {
   stream = 'stdout',
   ignore_exitcode = true,
   parser = function(output, bufnr)
-    if vim.trim(output) == "" then
+    local trimmed_output = vim.trim(output)
+    if trimmed_output == "" then
       return {}
     end
     local decode_opts = { luanil = { object = true, array = true } }
     local ok, data = pcall(vim.json.decode, output, decode_opts)
+    if string.find(trimmed_output, "No ESLint configuration found") then
+      vim.notify_once(trimmed_output, vim.log.levels.WARN)
+      return {}
+    end
     if not ok then
       return {
         {


### PR DESCRIPTION
Closed #462

When there's no ESLint config, the error is shown in the buffer, which is an annoying experience when a user is working on JS-related files that are not associated with a config.

<img width="1424" alt="Screenshot 2024-05-23 at 1 56 57 PM" src="https://github.com/mfussenegger/nvim-lint/assets/54052461/97299233-73d4-417a-97cd-757771bcebd0">

We should warn the user of the error once instead of showing the error in the buffer:

![Screenshot 2024-05-23 at 2 10 09 PM](https://github.com/mfussenegger/nvim-lint/assets/54052461/288c19ec-ecae-44fb-8128-023466286de0)






