### PR TITLE
trivy: bugfix: line reported as col; bugfix: crash on missing line from trivy; plus refinements

### DIFF
--- a/lua/lint/linters/trivy.lua
+++ b/lua/lint/linters/trivy.lua
@@ -9,11 +9,10 @@ return {
   cmd = "trivy",
   stdin = false,
   append_fname = true,
-  -- FIXME: '--scanners config' is deprecated in favor of '--scanners misconfig'
   -- NOTE: excluding '-q/--quiet' flag to receive log on stderr before the JSON on stdout.
   --       The log may contain errors and warnings that can be used to notify the user this script
   --       needs maintenance.
-  args = { "--scanners", "config", "--format", "json", "fs" },
+  args = { "--scanners", "misconfig", "--format", "json", "fs" },
   stream = "stdout",
   ignore_exitcode = false,
   parser = function(

--- a/lua/lint/linters/trivy.lua
+++ b/lua/lint/linters/trivy.lua
@@ -1,3 +1,4 @@
+-- Map trivy severity to vim.diagnostic severity
 local severity_map = {
   ["LOW"] = vim.diagnostic.severity.INFO,
   ["MEDIUM"] = vim.diagnostic.severity.WARN,
@@ -8,24 +9,59 @@ return {
   cmd = "trivy",
   stdin = false,
   append_fname = true,
+  -- FIXME: '--scanners config' is deprecated in favor of '--scanners misconfig'
+  -- NOTE: excluding '-q/--quiet' flag to receive log on stderr before the JSON on stdout.
+  --       The log may contain errors and warnings that can be used to notify the user this script
+  --       needs maintenance.
   args = { "--scanners", "config", "--format", "json", "fs" },
   stream = "stdout",
   ignore_exitcode = false,
-  parser = function(output, bufnr)
+  parser = function(
+    output, -- output from trivy (a JSON string)
+    bufnr -- nvim buffer number. Used to choose the correct Result from the JSON output
+  )
     local diagnostics = {}
+
+    -- TODO: Parse log messages from trivy that appear before the JSON.  Register any ERRORS or
+    --       WARNINGS as diagnostics so someone will know to make future updates to this script.
+    -- NOTE: Don't know how to get access to both stderr and stdout, so unable to address this
+    --       TODO.  Setting stream = 'both' only yields the stdout stream.
+
+    -- parse trivy output JSON
+    --
+    -- fields used:
+    -- {
+    --   "Results": [
+    --     "Target": "<file path>",
+    --     "Misconfigurations": [
+    --       "ID": "<nvim-lint code>",
+    --       "Title": "<title>",
+    --       "Description": "<description>",
+    --       "Severity": "<LOW|MEDIUM|HIGH>",
+    --       "CauseMetadata": {
+    --         "StartLine": <line number>,
+    --         "EndLine": <line number>,
+    --       }
+    --     ]
+    --   ]
+    -- }
     local ok, decoded = pcall(vim.json.decode, output)
     if not ok then
       return diagnostics
     end
+
     local fpath = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t")
+
     for _, result in ipairs(decoded and decoded.Results or {}) do
+      -- If trivy returns Results for multiple files, only consider those for bufnr
       if result.Target == fpath then
         for _, misconfig in ipairs(result.Misconfigurations or {}) do
+          -- FIXME: check all misconfig fields for nil before accesing
           local err = {
             source = "trivy",
             message = string.format("%s %s", misconfig.Title, misconfig.Description),
-            col = misconfig.CauseMetadata.StartLine,
-            end_col = misconfig.CauseMetadata.EndLine,
+            col = misconfig.CauseMetadata.StartLine, -- FIXME: trivy doesn't provide col info
+            end_col = misconfig.CauseMetadata.EndLine, -- FIXME: trivy doesn't provide col info
             lnum = misconfig.CauseMetadata.StartLine - 1,
             end_lnum = misconfig.CauseMetadata.EndLine - 1,
             code = misconfig.ID,
@@ -35,6 +71,7 @@ return {
         end
       end
     end
+
     return diagnostics
   end,
 }

--- a/lua/lint/linters/trivy.lua
+++ b/lua/lint/linters/trivy.lua
@@ -1,114 +1,65 @@
--- Map trivy severity to vim.diagnostic severity
 local severity_map = {
   ["LOW"] = vim.diagnostic.severity.INFO,
   ["MEDIUM"] = vim.diagnostic.severity.WARN,
   ["HIGH"] = vim.diagnostic.severity.ERROR,
 }
 
+
 return {
   cmd = "trivy",
   stdin = false,
   append_fname = true,
-  -- NOTE: excluding '-q/--quiet' flag to receive log on stderr before the JSON on stdout.
-  --       The log may contain errors and warnings that can be used to notify the user this script
-  --       needs maintenance.
   args = { "--scanners", "misconfig", "--format", "json", "fs" },
   stream = "stdout",
   ignore_exitcode = false,
-  parser = function(
-    output, -- output from trivy (a JSON string)
-    bufnr -- nvim buffer number. Used to choose the correct Result from the JSON output
-  )
+  parser = function(output, bufnr)
     local diagnostics = {}
 
-    -- TODO: Parse log messages from trivy that appear before the JSON.  Register any ERRORS or
-    --       WARNINGS as diagnostics so someone will know to make future updates to this script.
-    -- NOTE: Don't know how to get access to both stderr and stdout, so unable to address this
-    --       TODO.  Setting stream = 'both' only yields the stdout stream.
-
-    -- parse trivy output JSON
-    --
-    -- fields used:
+    -- example output:
     -- {
     --   "Results": [
     --     "Target": "<file path>",
     --     "Misconfigurations": [
-    --       "ID": "<nvim-lint code>",
-    --       "Title": "<title>",
-    --       "Description": "<description>",
-    --       "Severity": "<LOW|MEDIUM|HIGH>",
-    --       "CauseMetadata": {
-    --         "StartLine": <line number>,
-    --         "EndLine": <line number>,
-    --       }
+    --        {
+    --          "ID": "<nvim-lint code>",
+    --          "Title": "<title>",
+    --          "Description": "<description>",
+    --          "Severity": "<LOW|MEDIUM|HIGH>",
+    --          "CauseMetadata": {
+    --            "StartLine": <line number>,
+    --            "EndLine": <line number>,
+    --          }
+    --        }
     --     ]
     --   ]
     -- }
-    local ok, decoded = pcall(vim.json.decode, output)
-    if not ok then
-      return diagnostics
-    end
-
+    local decoded = vim.json.decode(output)
     local fpath = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t")
 
-    -- If these are not present, drop/skip the Misconfiguration
-    -- NOTE: Could also default and override the vim.diagnostic.severity
-    local required_misconfig_fields = { "Severity" }
-
     for _, result in ipairs(decoded and decoded.Results or {}) do
-      -- If trivy returns Results for multiple files, only consider those for bufnr
+      -- trivy can return Results for other files; only report for current buffer
+      --
       if result.Target == fpath then
         for _, misconfig in ipairs(result.Misconfigurations or {}) do
-          -- skip this misconfiguration if any required fields are missing
-          for _, field in ipairs(required_misconfig_fields or {}) do
-            if not misconfig[field] then
-              goto next_misconfig
-            end
-          end
-
-          local title = "<No Title>"
-          if misconfig.Title then
-            title = misconfig.Title
-          end
-
-          local description = "<No Description>"
-          if misconfig.Description then
-            description = misconfig.Description
-          end
-
-          local id = "<No ID>"
-          if misconfig.ID then
-            id = misconfig.ID
-          end
-
-          -- default start posi to first line, then override if StartLine exist
-          local lnum = 0
-          if misconfig.CauseMetadata and misconfig.CauseMetadata.StartLine then
-            lnum = misconfig.CauseMetadata.StartLine - 1
-          end
-
-          -- default end posi to start posi, then override if EndLine exist
-          local end_lnum = lnum
-          if misconfig.CauseMetadata and misconfig.CauseMetadata.EndLine then
-            end_lnum = misconfig.CauseMetadata.EndLine - 1
-          end
-
+          local title = misconfig.Title or "<No Title>"
+          local description = misconfig.Description or "<No Description>"
+          local id = misconfig.ID or "<No ID>"
+          local md = misconfig.CauseMetadata or {}
+          local lnum = md.StartLine and md.StartLine - 1 or 0
+          local end_lnum = md.EndLine and md.EndLine - 1 or 0
           table.insert(diagnostics, {
             source = "trivy",
             message = string.format("%s: %s", title, description),
-            col = 0, -- trivy doesn't provide col info; nvim-lint defaults to 0
-            end_col = 0, -- trivy doesn't provide col info; nvim-lint defaults to 0
+            col = 0,
+            end_col = 0,
             lnum = lnum,
             end_lnum = end_lnum,
             code = id,
-            severity = severity_map[misconfig.Severity],
+            severity = severity_map[misconfig.Severity] or vim.diagnostic.severity.WARN,
           })
-
-          ::next_misconfig::
-         end
+        end
       end
     end
-
     return diagnostics
   end,
 }

--- a/lua/lint/linters/trivy.lua
+++ b/lua/lint/linters/trivy.lua
@@ -60,8 +60,8 @@ return {
           local err = {
             source = "trivy",
             message = string.format("%s %s", misconfig.Title, misconfig.Description),
-            col = misconfig.CauseMetadata.StartLine, -- FIXME: trivy doesn't provide col info
-            end_col = misconfig.CauseMetadata.EndLine, -- FIXME: trivy doesn't provide col info
+            col = 0, -- trivy doesn't provide col info; nvim-lint defaults to 0
+            end_col = 0, -- trivy doesn't provide col info; nvim-lint defaults to 0
             lnum = misconfig.CauseMetadata.StartLine - 1,
             end_lnum = misconfig.CauseMetadata.EndLine - 1,
             code = misconfig.ID,

--- a/tests/trivy_spec.lua
+++ b/tests/trivy_spec.lua
@@ -87,11 +87,11 @@ describe("linter.trivy", function()
     local expected = {
       {
         source = "trivy",
-        message = "A KMS key is not configured to auto-rotate. You should configure your KMS keys to auto rotate to maintain security and defend against compromise.",
+        message = "A KMS key is not configured to auto-rotate.: You should configure your KMS keys to auto rotate to maintain security and defend against compromise.",
         lnum = 14,
         end_lnum = 14,
-        col = 15,
-        end_col = 15,
+        col = 0,
+        end_col = 0,
         severity = vim.diagnostic.severity.WARN,
         code = "AVD-AWS-0065",
       },


### PR DESCRIPTION
**Changes**

* bugfix: no longer reports trivy StartLine, EndLine as nvim-lint col, end_col
* bugfix: check parsed fields before building/inserting diagnostic
* cleanup: fix deprecated CLI arg: '--scanners config' -> '--scanners misconfig'
* comments: clarify intent to ease future maintainence

**Bug Descriptions**

Output from trivy sometimes includes line info, but not column info.  line info is used for both col and lnum in trivy.lua

Output from trivy does not always contain StartLine and EndLine fields.  When they are missing, diagnostics are not created for each Misconfiguration from trivy, but instead a single diagnostic is generated with a lua error about accessing a nil value (StartLine).

To reproduce, open the following Dockerfile with trivy enabled as a linter, then look at the reported diagnostics:
```
FROM ubuntu:24.04
LABEL maintainer="John Doe <john.doe@aol.com>"
```