### PR TITLE
Read stylelint output from stderr

### DIFF
--- a/lua/lint/linters/stylelint.lua
+++ b/lua/lint/linters/stylelint.lua
@@ -22,7 +22,7 @@ return {
       return vim.fn.expand("%:p")
     end,
   },
-  stream = "stdout",
+  stream = "stderr",
   ignore_exitcode = true,
   parser = function (output)
     local status, decoded = pcall(vim.json.decode, output)


### PR DESCRIPTION
The latest major release of `stylelint`, v16, [changed](https://stylelint.io/migration-guide/to-16/#changed-cli-to-print-problems-to-stderr) the program to output problems to stderr rather than to stdout, as before.

I have tested the proposed changed locally and have found it to work as expected.