### PR TITLE
stylelint: set stream to both

### DIFF
--- a/lua/lint/linters/stylelint.lua
+++ b/lua/lint/linters/stylelint.lua
@@ -22,7 +22,7 @@ return {
       return vim.fn.expand("%:p")
     end,
   },
-  stream = "stdout",
+  stream = "both",
   ignore_exitcode = true,
   parser = function (output)
     local status, decoded = pcall(vim.json.decode, output)


### PR DESCRIPTION
According to https://github.com/mfussenegger/nvim-lint/pull/518 using
`both` should work for the latest stable version but also older versions
