### PR TITLE
codespell: use stdin

### DIFF
--- a/lua/lint/linters/codespell.lua
+++ b/lua/lint/linters/codespell.lua
@@ -1,11 +1,15 @@
+-- stdout output in the form "63: resourcs ==> resources, resource"
+local pattern = "(%d+): (.*)"
+local groups = { "lnum", "message" }
+local severities = nil -- none provided
 
 return {
   cmd = 'codespell',
-  stdin = false,
+  args = { '--stdin-single-line', "-" },
+  stdin = true,
   ignore_exitcode = true,
-  parser = require('lint.parser').from_errorformat(
-    '%f:%l:%m',
-    { severity = vim.diagnostic.severity.INFO,
-      source = 'codespell'}
-  )
+  parser = require('lint.parser').from_pattern(pattern, groups, severities, {
+    source = 'codespell',
+    severity = vim.diagnostic.severity.INFO,
+  }),
 }


### PR DESCRIPTION
This PR enables the stdin mode for codespell.

This is a follow-up PR to https://github.com/mfussenegger/nvim-lint/pull/457 after the codespell has been released with required changes which simplify the output parsing.