### PR TITLE
Add ghdl linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ busted tests/
 [psalm]: https://psalm.dev/
 [lacheck]: https://www.ctan.org/tex-archive/support/lacheck
 [credo]: https://github.com/rrrene/credo
+[ghdl]: https://github.com/ghdl/ghdl
 [glslc]: https://github.com/google/shaderc
 [rubocop]: https://github.com/rubocop/rubocop
 [dxc]: https://github.com/microsoft/DirectXShaderCompiler

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Other dedicated linters that are built-in are:
 | [Flake8][13]                           | `flake8`               |
 | [flawfinder][35]                       | `flawfinder`           |
 | [gdlint (gdtoolkit)][gdlint]           | `gdlint`               |
+| [GHDL][ghdl]                           | `ghdl`                 |
 | [gitlint][gitlint]                     | `gitlint`              |
 | [glslc][glslc]                         | `glslc`                |
 | [Golangci-lint][16]                    | `golangcilint`         |

--- a/lua/lint/linters/ghdl.lua
+++ b/lua/lint/linters/ghdl.lua
@@ -1,0 +1,16 @@
+local pattern = "([^:]+):(%d+):(%d+):(.+)"
+local groups = { "file", "lnum", "col", "message" }
+local severity_map = {
+  ["error"] = vim.diagnostic.severity.ERROR,
+}
+
+return {
+  cmd = "ghdl",
+  stdin = false,
+  args = { "-s", "--std=08" },
+  stream = "stderr",
+  ignore_exitcode = true,
+  parser = require("lint.parser").from_pattern(pattern, groups, severity_map, {
+    source = "ghdl",
+  }),
+}


### PR DESCRIPTION
Adds a VHDL linter using [GHDL](https://github.com/ghdl/ghdl) discussed in #253, but which was never actually implemented.