### PR TITLE
Add VSG linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Other dedicated linters that are built-in are:
 | [Vale][8]                              | `vale`                 |
 | [Verilator][verilator]                 | `verilator`            |
 | [vint][21]                             | `vint`                 |
+| [VSG][vsg]                             | `vsg`                  |
 | [vulture][vulture]                     | `vulture`              |
 | [woke][woke]                           | `woke`                 |
 | [write-good][write-good]               | `write_good`           |
@@ -446,6 +447,7 @@ busted tests/
 [jsonlint]: https://github.com/zaach/jsonlint
 [rflint]: https://github.com/boakley/robotframework-lint
 [robocop]: https://github.com/MarketSquare/robotframework-robocop
+[vsg]: https://github.com/jeremiah-c-leary/vhdl-style-guide
 [vulture]: https://github.com/jendrikseipp/vulture
 [yamllint]: https://github.com/adrienverge/yamllint
 [cpplint]: https://github.com/cpplint/cpplint

--- a/lua/lint/linters/vsg.lua
+++ b/lua/lint/linters/vsg.lua
@@ -1,0 +1,45 @@
+local pattern = "(%w+).*%((%d+)%)(.*)%s+%-%-%s+(.+)"
+local groups = { "severity", "lnum", "code", "message" }
+local severity_map = {
+  ["ERROR"] = vim.diagnostic.severity.ERROR,
+  ["WARNING"] = vim.diagnostic.severity.WARN,
+  ["INFORMATION"] = vim.diagnostic.severity.INFO,
+  ["HINT"] = vim.diagnostic.severity.HINT,
+}
+
+local function find_local_config()
+  local current_file = vim.api.nvim_buf_get_name(0)
+  local filenames = { ".vsg.yaml", ".vsg.yml", ".vsg.json" }
+  return vim.fs.find(filenames, {
+    path = vim.fs.dirname(current_file),
+    upward = true,
+  })[1]
+end
+
+local function find_global_config()
+  local xdg_config_home = os.getenv("XDG_CONFIG_HOME") or os.getenv("HOME") .. "/.config"
+  local filenames = { "vsg.yaml", "vsg.yml", "vsg.json" }
+  return vim.fs.find(filenames, {
+    path = xdg_config_home .. "/vsg",
+    upward = false,
+  })[1]
+end
+
+local config_file = find_local_config() or find_global_config()
+local args = { "-of", "syntastic", "--stdin" }
+
+if config_file then
+  table.insert(args, "-c")
+  table.insert(args, config_file)
+end
+
+return {
+  cmd = "vsg",
+  stdin = true,
+  args = args,
+  stream = "stdout",
+  ignore_exitcode = true,
+  parser = require("lint.parser").from_pattern(pattern, groups, severity_map, {
+    source = "vsg",
+  }),
+}

--- a/lua/lint/linters/vsg.lua
+++ b/lua/lint/linters/vsg.lua
@@ -39,25 +39,27 @@ local function find_config(dirname)
   end
 end
 
-local function get_args(dirname)
-  local args = { "-of", "syntastic", "--stdin" }
-  local config_file = find_config(dirname)
+return function()
+  local args = function()
+    local args = { "-of", "syntastic", "--stdin" }
+    local config_file = find_config(vim.fn.expand("%:p:h"))
 
-  if config_file then
-    table.insert(args, "-c")
-    table.insert(args, config_file)
+    if config_file then
+      table.insert(args, "-c")
+      table.insert(args, config_file)
+    end
+
+    return args
   end
 
-  return args
+  return {
+    cmd = "vsg",
+    stdin = true,
+    args = args(),
+    stream = "stdout",
+    ignore_exitcode = true,
+    parser = require("lint.parser").from_pattern(pattern, groups, severity_map, {
+      source = "vsg",
+    }),
+  }
 end
-
-return {
-  cmd = "vsg",
-  stdin = true,
-  args = get_args(vim.fn.expand("%:p:h")),
-  stream = "stdout",
-  ignore_exitcode = true,
-  parser = require("lint.parser").from_pattern(pattern, groups, severity_map, {
-    source = "vsg",
-  }),
-}


### PR DESCRIPTION
Adds the [VHDL Style Guide](https://github.com/jeremiah-c-leary/vhdl-style-guide) (VSG) linter.

The linter doesn't autodetect configuration files, so I added functionality to look for `.vsg.yaml` and `.vsg.json` in the file's directory and in `xdg-config/vsg` or `~/.config/vsg`. I could not find any mention of a standard name for said files in the documentation, but I read some people using these names and so do I. I'm not sure if this is out of scope, but it is quite nice. Please let me know.