### PR TITLE
feat(codespell): support parsing the standard return format of codesp…

### DIFF
--- a/lua/lint/linters/codespell.lua
+++ b/lua/lint/linters/codespell.lua
@@ -1,15 +1,77 @@
--- stdout output in the form "63: resourcs ==> resources, resource"
-local pattern = "(%d+): (.*)"
-local groups = { "lnum", "message" }
-local severities = nil -- none provided
+--- Sanitizes a string by escaping special Lua pattern characters.
+-- This function replaces special characters used in Lua patterns with their escaped counterparts.
+---@param str (string) The input string to be sanitized.
+---@return (string) The sanitized string with escaped pattern characters.
+local function sanitize(str)
+  local rep_tbl = {
+    ["%"] = "%%",
+    ["-"] = "%-",
+    ["+"] = "%+",
+    ["*"] = "%*",
+    ["?"] = "%?",
+    ["^"] = "%^",
+    ["$"] = "%$",
+    ["."] = "%.",
+    ["("] = "%(",
+    [")"] = "%)",
+    ["["] = "%[",
+    ["]"] = "%]",
+  }
+
+  for what, with in pairs(rep_tbl) do
+    what = string.gsub(what, "[%(%)%.%+%-%*%?%[%]%^%$%%]", "%%%1") -- escape pattern
+    with = string.gsub(with, "[%%]", "%%%%")                       -- escape replacement
+    str = string.gsub(str, what, with)
+  end
+
+  return str
+end
+
 
 return {
   cmd = 'codespell',
-  args = { '--stdin-single-line', "-" },
+  args = { "-" },
   stdin = true,
   ignore_exitcode = true,
-  parser = require('lint.parser').from_pattern(pattern, groups, severities, {
-    source = 'codespell',
-    severity = vim.diagnostic.severity.INFO,
-  }),
+  parser = function(output, bufnr, _)
+    if output == '' then
+      return {}
+    end
+
+    local pat_diag = "(%d+): - [^\n]+\n\t((%S+)[^\n]+)"
+    local info = {}
+
+    for row, message, misspelled in output:gmatch(pat_diag) do
+      row = tonumber(row)
+      if misspelled ~= nil then
+        local lines = vim.api.nvim_buf_get_lines(bufnr, row >= 1 and row - 1 or 0, row, false)
+        if #lines == 1 then
+          misspelled = sanitize(misspelled)
+          local line = lines[1]
+          local col, end_col = line:find(misspelled)
+
+          if col == nil then
+            col = 0
+          end
+
+          if end_col == nil then
+            end_col = 0
+          end
+
+          table.insert(info, {
+            lnum = row - 1,
+            row = row,
+            col = col,
+            enl_lnum = row,
+            end_col = end_col + 1,
+            source = "codespell",
+            message = message,
+            severity = vim.diagnostic.severity.INFO,
+          })
+        end
+      end
+    end
+
+    return info
+  end
 }


### PR DESCRIPTION
…ell and provide standard vim info hints containing accurate line and column information.

The initial implementation of the codespell linter only supported parsing lines. This commit adds column parsing, thereby supporting more accurate hint displays.

Before:

<img width="1445" alt="image" src="https://github.com/mfussenegger/nvim-lint/assets/41188874/8bdfba6a-c6a3-4f4f-84ae-17fdd17eb29c">


After: 

<img width="1493" alt="image" src="https://github.com/mfussenegger/nvim-lint/assets/41188874/5802b540-66d3-4f90-8673-4a70de23d1cc">

