### PR TITLE
Ppass cwd to linter command

### DIFF
--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -264,9 +264,9 @@ function M.try_lint(names, opts)
   running_procs_by_buf[bufnr] = running_procs
 end
 
-local function eval_fn_or_id(x)
+local function eval_fn_or_id(x, opts)
   if type(x) == 'function' then
-    return x()
+    return x(opts)
   else
     return x
   end
@@ -321,7 +321,7 @@ function M.lint(linter, opts)
     -- pop up shortly.
     detached = not iswin
   }
-  local cmd = eval_fn_or_id(linter.cmd)
+  local cmd = eval_fn_or_id(linter.cmd, opts)
   assert(cmd, 'Linter definition must have a `cmd` set: ' .. vim.inspect(linter))
   handle, pid_or_err = uv.spawn(cmd, linter_opts, function(code)
     if handle and not handle:is_closing() then

--- a/lua/lint/linters/biomejs.lua
+++ b/lua/lint/linters/biomejs.lua
@@ -29,8 +29,13 @@
 local binary_name = "biome"
 
 return {
-  cmd = function()
-    local local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+  cmd = function(opts)
+    local local_binary;
+    if opts.cwd then
+      local_binary = vim.fn.fnamemodify(opts.cwd .. '/node_modules/.bin/' .. binary_name, ':p')
+    else
+      local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+    end
     return vim.loop.fs_stat(local_binary) and local_binary or binary_name
   end,
   args = { "lint" },

--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -5,8 +5,14 @@ local severities = {
 }
 
 return {
-  cmd = function()
-    local local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+  cmd = function(opts)
+    local local_binary;
+    if opts.cwd then
+      local_binary = vim.fn.fnamemodify(opts.cwd .. '/node_modules/.bin/' .. binary_name, ':p')
+    else
+      local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+    end
+
     return vim.loop.fs_stat(local_binary) and local_binary or binary_name
   end,
   args = {

--- a/lua/lint/linters/eslint_d.lua
+++ b/lua/lint/linters/eslint_d.lua
@@ -1,7 +1,12 @@
 local binary_name = "eslint_d"
 return {
-  cmd = function()
-    local local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+  cmd = function(opts)
+    local local_binary;
+    if opts.cwd then
+      local_binary = vim.fn.fnamemodify(opts.cwd .. '/node_modules/.bin/' .. binary_name, ':p')
+    else
+      local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+    end
     return vim.loop.fs_stat(local_binary) and local_binary or binary_name
   end,
   args = {

--- a/lua/lint/linters/markuplint.lua
+++ b/lua/lint/linters/markuplint.lua
@@ -6,8 +6,13 @@ local severity_map = {
 }
 
 return {
-  cmd = function()
-    local local_binary = vim.fn.fnamemodify("./node_modules/.bin/" .. binary_name, ":p")
+  cmd = function(opts)
+    local local_binary;
+    if opts.cwd then
+      local_binary = vim.fn.fnamemodify(opts.cwd .. '/node_modules/.bin/' .. binary_name, ':p')
+    else
+      local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+    end
     return vim.loop.fs_stat(local_binary) and local_binary or binary_name
   end,
   args = { "--format", "JSON" },

--- a/lua/lint/linters/prisma-lint.lua
+++ b/lua/lint/linters/prisma-lint.lua
@@ -1,8 +1,13 @@
 local binary_name = "prisma-lint"
 
 return {
-  cmd = function()
-    local local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+  cmd = function(opts)
+    local local_binary;
+    if opts.cwd then
+      local_binary = vim.fn.fnamemodify(opts.cwd .. '/node_modules/.bin/' .. binary_name, ':p')
+    else
+      local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+    end
     return vim.loop.fs_stat(local_binary) and local_binary or binary_name
   end,
   stdin = false,

--- a/lua/lint/linters/stylelint.lua
+++ b/lua/lint/linters/stylelint.lua
@@ -1,11 +1,19 @@
+local binary_name = "stylelint"
+
 local severities = {
   warning = vim.diagnostic.severity.WARN,
   error = vim.diagnostic.severity.ERROR,
 }
 
 return {
-  cmd = function()
-    local local_stylelint = vim.fn.fnamemodify("./node_modules/.bin/stylelint", ":p")
+  cmd = function(opts)
+    local local_stylelint;
+    if opts.cwd then
+      local_stylelint = vim.fn.fnamemodify(opts.cwd .. '/node_modules/.bin/' .. binary_name, ':p')
+    else
+      local_stylelint = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
+    end
+
     local stat = vim.loop.fs_stat(local_stylelint)
     if stat then
       return local_stylelint


### PR DESCRIPTION
Node.js linters (eslint, stylelint, etc) run binary from relative `node_modules` that depend on the working directory. But not always working directory has `node_modules`, in the case of monorepo it can be some sub-folder.

The lint run command already has `cwd` option, but doesn't pass it to `cmd` command.
The fix is passing opts to linter `cmd` to properly calculate the path to `node_modules` if it's not in working directory.