### PR TITLE
Use `ruff check` subcommand

### DIFF
--- a/lua/lint/linters/ruff.lua
+++ b/lua/lint/linters/ruff.lua
@@ -13,6 +13,7 @@ return {
   cmd = "ruff",
   stdin = true,
   args = {
+    "check",
     "--force-exclude",
     "--quiet",
     "--stdin-filename",


### PR DESCRIPTION
Use `ruff check` subcommand instead of relying on the default behavior which has been deprecated and will be removed in v0.5: https://github.com/astral-sh/ruff/pull/12011.