### PR TITLE
fix: unicode string length

### DIFF
--- a/lua/lint/linters/cspell.lua
+++ b/lua/lint/linters/cspell.lua
@@ -20,7 +20,7 @@ return {
         local lnum = math.max(0, item.lnum - 1)
         local col = math.max(0, item.col - 1)
         local end_lnum = item.end_lnum > 0 and (item.end_lnum - 1) or lnum
-        local end_col = col + word:len() - 2 or col
+        local end_col = col + vim.fn.strdisplaywidth(word) - 2 or col
         local diagnostic = {
           lnum = lnum,
           col = col,


### PR DESCRIPTION
CSpell parser doesn't calculate Unicode string length right.
```lua
string.len('Йоу') -- cyrillic string return 6 instead of 3
```
Lua 5.1 doesn't have a standard library for unicode strings, so I used a Vim function.