### PR TITLE
fix(stylelint): Shell escape file names/paths

### DIFF
--- a/lua/lint/linters/stylelint.lua
+++ b/lua/lint/linters/stylelint.lua
@@ -19,7 +19,7 @@ return {
     "--stdin",
     "--stdin-filename",
     function()
-      return vim.fn.expand("%:p")
+      return vim.fn.shellescape(vim.fn.expand("%:p"))
     end,
   },
   stream = "both",
@@ -34,7 +34,9 @@ return {
           {
             line = 1,
             column = 1,
-            text = "Stylelint error, run `stylelint " .. vim.fn.expand("%") .. "` for more info.",
+            text = "Stylelint error, run `stylelint "
+              .. vim.fn.shellescape(vim.fn.expand("%"))
+              .. "` for more info.",
             severity = "error",
             rule = "none",
           },


### PR DESCRIPTION
## Problem
Currently, stylelint fails to lint files when there are spaces in the file path. This causes issues for users with spaces in their directory or file names, preventing proper linting of their CSS files.

## Solution
This PR wraps file paths with `vim.fn.shellescape()` to properly handle edge cases where file paths contain spaces or other characters that require quoting or escaping.

## Changes
- Modified the `args` function to use `vim.fn.shellescape()` when passing the file path.
- Updated the error message construction in the parser to also use `vim.fn.shellescape()`.

## Testing
Tested with file paths containing spaces:
- Regular file: ✅
- File with spaces in name: ✅
- File in directory with spaces: ✅

## Impact
This change ensures that stylelint works correctly regardless of file path structure.