### PR TITLE
fix(terraform_validate): update terraform to validate at root dir

### DIFF
--- a/lua/lint/linters/terraform_validate.lua
+++ b/lua/lint/linters/terraform_validate.lua
@@ -7,7 +7,9 @@ local terraform_severity_to_diagnostic_severity = {
 return function()
   return {
     cmd = 'terraform',
-    args = { 'validate', '-json' },
+    args = function()
+      return { "-chdir", vim.fs.dirname(vim.api.nvim_buf_get_name(0)), "validate", "-json" }
+    end,
     append_fname = false,
     stdin = false,
     stream = 'both',


### PR DESCRIPTION
## Problem
Currently, `terraform_validate` fails to lint files properly when you subdivide the directory into a module structure as it performs `terraform_validate` at the module directory level.

## Solution
This PR add new command argument `-chdir` with `vim.fs.dirname(vim.api.nvim_buf_get_name(0))` to properly run the command at the root of project directory

## Changes
Modified the args function to use `-chdir vim.fs.dirname(vim.api.nvim_buf_get_name(0))` to run the terraform validate command.

## Testing
Tested with file paths containing the module structure and without. Module structured files are correctly linted as a whole terraform project instead of individual standalone files.

## Impact
This change ensures that `terraform_validate` works correctly regardless of directory structure of your terraform project.