### PR TITLE
fix(credo): credo now respects .credo.exs

### DIFF
--- a/lua/lint/linters/credo.lua
+++ b/lua/lint/linters/credo.lua
@@ -1,10 +1,18 @@
-local errorfmt = '[%t] %. stdin:%l:%c %m, [%t] %. stdin:%l %m'
+local pattern = "%[%a%]%s+(.+)%s+([^:]+):(%d+):?(%d*)%s+(.*)"
+local groups = { "severity", "file", "lnum", "col", "message" }
+local severity = {
+  ["↑"] = vim.diagnostic.severity.ERROR,
+  ["↗"] = vim.diagnostic.severity.WARN,
+  ["→"] = vim.diagnostic.severity.INFO,
+  ["↘"] = vim.diagnostic.severity.HINT,
+  ["↓"] = vim.diagnostic.severity.HINT,
+}
 
 return {
-  cmd = 'mix',
-  stdin = true,
-  args = { 'credo', 'list', '--format=oneline', '--read-from-stdin', '--strict'},
-  stream = 'stdout',
+  cmd = "mix",
+  stdin = false,
+  args = { "credo", "list", "--format=oneline", "--strict" },
+  stream = "stdout",
   ignore_exitcode = true, -- credo only returns 0 if there are no errors
-  parser = require('lint.parser').from_errorformat(errorfmt, { ['source'] = 'credo' })
+  parser = require("lint.parser").from_pattern(pattern, groups, severity, { ["source"] = "credo" }),
 }

--- a/tests/credo_spec.lua
+++ b/tests/credo_spec.lua
@@ -1,13 +1,14 @@
-describe('linter.credo', function()
-  it('can parse the output', function()
-    local parser = require('lint.linters.credo').parser
+describe("linter.credo", function()
+  it("can parse the output", function()
+    local parser = require("lint.linters.credo").parser
+    local bufnr = vim.uri_to_bufnr("file:///foo.ex")
     -- taken from example screenshot from credo's documentation https://hexdocs.pm/credo/overview.html
     -- 3rd record shouldn't get picked up because there is no file/line information
-    local result = parser([[
-[R] → stdin:1:11 Unless conditions should avoid having an `else` block.
-[W] ↗ stdin:9:5 Use `reraise` inside a rescue block to preserve the original stacktrace.
+    local result = parser( [[
+[R] → /foo.ex:1:11 Unless conditions should avoid having an `else` block.
+[W] ↗ /foo.ex:9:5 Use `reraise` inside a rescue block to preserve the original stacktrace.
 [W] ↗ Exception modules should be named consistently. It seems your strategy is to have `Error` ....
-]])
+]], bufnr)
     assert.are.same(2, #result)
 
     local expected_error = {
@@ -15,9 +16,9 @@ describe('linter.credo', function()
       end_col = 10,
       lnum = 0,
       end_lnum = 0,
-      severity = 1,
-      message = 'Unless conditions should avoid having an `else` block.',
-      source = 'credo',
+      severity = 3,
+      message = "Unless conditions should avoid having an `else` block.",
+      source = "credo",
     }
 
     assert.are.same(expected_error, result[1])
@@ -28,8 +29,8 @@ describe('linter.credo', function()
       lnum = 8,
       end_lnum = 8,
       severity = 2,
-      message = 'Use `reraise` inside a rescue block to preserve the original stacktrace.',
-      source = 'credo',
+      message = "Use `reraise` inside a rescue block to preserve the original stacktrace.",
+      source = "credo",
     }
 
     assert.are.same(expected_error, result[2])


### PR DESCRIPTION
I changed credo spec to pass around the filename. This is important because credo has defaults that disable some checks for certain directories. And if the repo has a `.credo.exs` file, credo needs to know the filename that it is checking.

I also created the severity mapping.

(I could not run the tests on my machine, so I want to run the CI to see if everything works).