### PR TITLE
fix(mypy): make mypy respect the current python environment

### DIFF
--- a/lua/lint/linters/mypy.lua
+++ b/lua/lint/linters/mypy.lua
@@ -19,6 +19,10 @@ return {
     '--no-color-output',
     '--no-error-summary',
     '--no-pretty',
+    '--python-executable',
+    function()
+      return vim.fn.exepath 'python3' or vim.fn.exepath 'python'
+    end
   },
   parser = require('lint.parser').from_pattern(
     pattern,


### PR DESCRIPTION
At the moment, the plugin will just run the global `mypy`, which, if installed via mason, will then only use system-level python3. If the user hasn't installed mypy through mason but has mypy installed in their locally activated python environment, it works fine though but I feel that's a bit suboptimal as you then need to install mypy into every custom environment you make.

To fix this I initially added the following to my nvim-lint config block:
```lua
      vim.list_extend(lint.linters.mypy.args, {
        '--python-executable',
        function()
          return vim.fn.exepath 'python3' or vim.fn.exepath 'python'
        end,
      })
```
and this works pretty much perfectly and should also work cross platform with basically any virtual env management system. This PR simply integrates this into the mypy configuration in nvim-lint.