### PR TITLE
fix(clippy): use relative path instead of absolute

### DIFF
--- a/lua/lint/linters/clippy.lua
+++ b/lua/lint/linters/clippy.lua
@@ -38,6 +38,7 @@ return {
     local diagnostics = {}
     local items = #output > 0 and vim.split(output, "\n") or {}
     local file_name = vim.api.nvim_buf_get_name(bufnr)
+    file_name = vim.fn.fnamemodify(file_name, ":.")
 
     for _, i in ipairs(items) do
       local item = i ~= "" and vim.json.decode(i) or {}


### PR DESCRIPTION
Sorry, I should have tested it out beforehand. Clippy returns the source file as relative to the directory and I had completely forgotten nvim_buf_get_name() returns the file as an absolute path.