### PR TITLE
Return table instead of a function for vsg

### DIFF
--- a/lua/lint/linters/vsg.lua
+++ b/lua/lint/linters/vsg.lua
@@ -39,8 +39,10 @@ local function find_config(dirname)
   end
 end
 
-return function()
-  local args = function()
+return {
+  cmd = "vsg",
+  stdin = true,
+  args = function()
     local args = { "-of", "syntastic", "--stdin" }
     local config_file = find_config(vim.fn.expand("%:p:h"))
 
@@ -50,16 +52,10 @@ return function()
     end
 
     return args
-  end
-
-  return {
-    cmd = "vsg",
-    stdin = true,
-    args = args(),
-    stream = "stdout",
-    ignore_exitcode = true,
-    parser = require("lint.parser").from_pattern(pattern, groups, severity_map, {
-      source = "vsg",
-    }),
-  }
-end
+  end,
+  stream = "stdout",
+  ignore_exitcode = true,
+  parser = require("lint.parser").from_pattern(pattern, groups, severity_map, {
+    source = "vsg",
+  }),
+}

--- a/lua/lint/linters/vsg.lua
+++ b/lua/lint/linters/vsg.lua
@@ -39,10 +39,7 @@ local function find_config(dirname)
   end
 end
 
-return {
-  cmd = "vsg",
-  stdin = true,
-  args = function()
+local function get_args()
     local args = { "-of", "syntastic", "--stdin" }
     local config_file = find_config(vim.fn.expand("%:p:h"))
 
@@ -52,7 +49,12 @@ return {
     end
 
     return args
-  end,
+end
+
+return {
+  cmd = "vsg",
+  stdin = true,
+  args = get_args(),
   stream = "stdout",
   ignore_exitcode = true,
   parser = require("lint.parser").from_pattern(pattern, groups, severity_map, {


### PR DESCRIPTION
Refactor vsg.lua to return a table instead of a function as it prevents from changing the default configuration just partially.

In my case I just wanted to modify the `args` used by the linter but since `lint.linter.vsg` was a function I had to redefine it entirely. By returning a table i can just do the following in the config files:
```lua
      local ok, vsg = pcall(require, 'lint.linters.vsg')
      if ok then
        vsg.args = { <my args> }
      end
```   