### PR TITLE
codespell: Provide col/end_col information

### DIFF
--- a/lua/lint/linters/codespell.lua
+++ b/lua/lint/linters/codespell.lua
@@ -1,15 +1,35 @@
 -- stdout output in the form "63: resourcs ==> resources, resource"
+local api = vim.api
 local pattern = "(%d+): (.*)"
 local groups = { "lnum", "message" }
 local severities = nil -- none provided
-
+local parser = require('lint.parser').from_pattern(pattern, groups, severities, {
+  source = 'codespell',
+  severity = vim.diagnostic.severity.INFO,
+})
 return {
   cmd = 'codespell',
   args = { '--stdin-single-line', "-" },
   stdin = true,
   ignore_exitcode = true,
-  parser = require('lint.parser').from_pattern(pattern, groups, severities, {
-    source = 'codespell',
-    severity = vim.diagnostic.severity.INFO,
-  }),
+  parser = function(output, bufnr, cwd)
+    local result = parser(output, bufnr, cwd)
+    for _, d in ipairs(result) do
+      local start, _, capture = d.message:find("(.*) ==>")
+      if start then
+        -- lenient - lint is async and buffer can change between lint start and result parsing
+        local ok, lines = pcall(api.nvim_buf_get_lines, bufnr, d.lnum, d.lnum + 1, true)
+        if ok then
+          local line = lines[1] or ""
+          local end_
+          start, end_ = line:find(vim.pesc(capture))
+          if start then
+            d.col = start - 1
+            d.end_col = end_
+          end
+        end
+      end
+    end
+    return result
+  end,
 }

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -51,6 +51,7 @@ local normalize = (vim.fs ~= nil and vim.fs.normalize ~= nil)
 ---@param severity_map? table<string, vim.diagnostic.Severity>
 ---@param defaults? table
 ---@param opts? {col_offset?: integer, end_col_offset?: integer, lnum_offset?: integer, end_lnum_offset?: integer}
+---@return fun(output: string, bufnr: integer, cwd: string):lsp.Diagnostic[]
 function M.from_pattern(pattern, groups, severity_map, defaults, opts)
   defaults = defaults or {}
   severity_map = severity_map or {}

--- a/tests/codespell_spec.lua
+++ b/tests/codespell_spec.lua
@@ -1,0 +1,21 @@
+local api = vim.api
+describe("codespell", function()
+  it("provides end_col", function()
+    local parser = require("lint.linters.codespell").parser
+    local bufnr = api.nvim_create_buf(false, true)
+    api.nvim_buf_set_lines(bufnr, 0, -1, true, {'  error("hello crate test")'})
+    local result = parser("1: crate ==> create", bufnr)
+    local expected = {
+      {
+        col = 15,
+        end_col = 20,
+        end_lnum = 0,
+        lnum = 0,
+        message = 'crate ==> create',
+        severity = vim.diagnostic.severity.INFO,
+        source = 'codespell',
+      }
+    }
+    assert.are.same(expected, result)
+  end)
+end)


### PR DESCRIPTION
Alternative to https://github.com/mfussenegger/nvim-lint/pull/602
Given that the linter doesn't actually output col/end_col information
this looks for the misspelled words in the buffer

Note that if the same misspelled word occurs more than once in a line,
it will erroneously report all the errors in the first location.
