### PR TITLE
fix(sqlfluff): Disambiguate sqlfluff diagnostics

### DIFF
--- a/lua/lint/linters/sqlfluff.lua
+++ b/lua/lint/linters/sqlfluff.lua
@@ -33,11 +33,15 @@ return {
     local diagnostics = {}
     for _, i_filepath in ipairs(per_filepath) do
         for _, violation in ipairs(i_filepath.violations) do
+          local severity = vim.diagnostic.severity.WARN
+          if violation.code == "PRS" then
+            severity = vim.diagnostic.severity.ERROR
+          end
           table.insert(diagnostics, {
             source = 'sqlfluff',
             lnum = (violation.line_no or violation.start_line_no) - 1,
             col = (violation.line_pos or violation.start_line_pos) - 1,
-            severity = vim.diagnostic.severity.ERROR,
+            severity = severity,
             message = violation.description,
             user_data = {lsp = {code = violation.code}},
           })

--- a/tests/sqlfluff_spec.lua
+++ b/tests/sqlfluff_spec.lua
@@ -3,6 +3,7 @@ describe('linter.sqlfluff', function()
     local parser = require('lint.linters.sqlfluff').parser
     local bufnr = vim.uri_to_bufnr('file:///non-existent.sql')
     -- actual output I got from running sqlfluff
+    -- NB: These tests do not address parsing failures
     local result = parser([[
 [{"filepath": "stdin", "violations": [{"start_line_no": 68, "start_line_pos": 1, "code": "L003", "description": "Expected 1 indentation, found 0 [compared to line 52]"}, {"start_line_no": 68, "start_line_pos": 1, "code": "L013", "description": "Column expression without alias. Use explicit `AS` clause."}]}]
 
@@ -15,7 +16,7 @@ describe('linter.sqlfluff', function()
       message = 'Expected 1 indentation, found 0 [compared to line 52]',
       lnum = 67, -- mind the line indexing
       col = 0, -- mind the column indexing
-      severity = vim.diagnostic.severity.ERROR,
+      severity = vim.diagnostic.severity.WARN,
       user_data = {lsp = {code = 'L003'}},
     }
     assert.are.same(expected[1], result[1])
@@ -25,7 +26,7 @@ describe('linter.sqlfluff', function()
       message = 'Column expression without alias. Use explicit `AS` clause.',
       lnum = 67,
       col = 0,
-      severity = vim.diagnostic.severity.ERROR,
+      severity = vim.diagnostic.severity.WARN,
       user_data = {lsp = {code = 'L013'}},
     }
     assert.are.same(expected[2], result[2])
@@ -47,7 +48,7 @@ describe('linter.sqlfluff', function()
       message = 'Expected 1 indentation, found 0 [compared to line 52]',
       lnum = 67, -- mind the line indexing
       col = 0, -- mind the column indexing
-      severity = vim.diagnostic.severity.ERROR,
+      severity = vim.diagnostic.severity.WARN,
       user_data = {lsp = {code = 'L003'}},
     }
     assert.are.same(expected[1], result[1])
@@ -57,7 +58,7 @@ describe('linter.sqlfluff', function()
       message = 'Column expression without alias. Use explicit `AS` clause.',
       lnum = 67,
       col = 0,
-      severity = vim.diagnostic.severity.ERROR,
+      severity = vim.diagnostic.severity.WARN,
       user_data = {lsp = {code = 'L013'}},
     }
     assert.are.same(expected[2], result[2])


### PR DESCRIPTION
Sqlfluff does not provide severity codes in its messages. The original defaulted everything to `ERROR`. This change downgrades regular messages to `WARN` and only flags the code for a parsing error as `ERROR`. This is done because Sqlfluff formatting will fail if a parsing error occurs, and identifying the error is much easier when a distinction is made between errors and warnings.