### PR TITLE
feat: Use npm installed package when possible

### DIFF
--- a/lua/lint/linters/standardjs.lua
+++ b/lua/lint/linters/standardjs.lua
@@ -17,8 +17,10 @@ local severities = {
   ['warning'] = vim.diagnostic.severity.WARN
 }
 
+local binary_name = "standard"
+
 return {
-  cmd = 'standard',
+  cmd = require("lint.util").from_node_modules(binary_name),
   stdin = true,
   args = { "--stdin" },
   ignore_exitcode = true,


### PR DESCRIPTION
I added two utils functions to search for commands to use as linter executable. These functions were ported from `conform.nvim` and have been adapted to `nvim-lint` as suggested in #519 

With these functions it is easy to setup linters that may have a local installation but are allowed to fallback to a system wide binary if no local is found.

I had no time to setup test execution, hopefully CI can do its work :). I manually tested that standardjs keeps working, so there shouldn't be any problem.