### PR TITLE
Correct GolangCI-Lint Installation Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Other dedicated linters that are built-in are:
 | [GHDL][ghdl]                           | `ghdl`                 |
 | [gitlint][gitlint]                     | `gitlint`              |
 | [glslc][glslc]                         | `glslc`                |
-| [Golangci-lint][16]                    | `golangcilint`         |
+| [Golangci-lint][16]                    | `golangci-lint`        |
 | [hadolint][28]                         | `hadolint`             |
 | [hledger][hledger]                     | `hledger`              |
 | [hlint][32]                            | `hlint`                |


### PR DESCRIPTION
The current documentation incorrectly refers to the Go linter as `golangcilint`. Users attempting to install the linter with this name encounter the error: "couldn't find golangcilint."

This issue arises due to a missing hyphen in the command. The correct name of the linter is `golangci-lint`. This update rectifies the command to ensure that users can install the linter without encountering errors.