### PR TITLE
fix: prevent cmd.exe taking over tab title

### DIFF
--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -321,6 +321,10 @@ function M.lint(linter, opts)
     -- pop up shortly.
     detached = not iswin
   }
+  -- prevents cmd.exe taking over the tab title
+  if iswin then
+    linter_opts.hide = true
+  end
   local cmd = eval_fn_or_id(linter.cmd)
   assert(cmd, 'Linter definition must have a `cmd` set: ' .. vim.inspect(linter))
   handle, pid_or_err = uv.spawn(cmd, linter_opts, function(code)


### PR DESCRIPTION
#648 indicates that `C:\WINDOWS\system32\cmd.exe` takes over tab title even when `:set title`. Setting `options.hide` in `uv.spawn` can hide the subprocess console window, and display title on the tab.

Closes #648.