### PR TITLE
Add awk linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Other dedicated linters that are built-in are:
 | [alex][alex]                           | `alex`                 |
 | [ameba][ameba]                         | `ameba`                |
 | [ansible-lint][ansible-lint]           | `ansible_lint`         |
+| [awk][awk]                             | `awk`                  |
 | [bandit][bandit]                       | `bandit`               |
 | [bean-check][bean-check]               | `bean_check`           |
 | [biomejs][biomejs]                     | `biomejs`              |
@@ -564,3 +565,4 @@ busted tests/
 [clippy]: https://github.com/rust-lang/rust-clippy
 [hledger]: https://hledger.org/
 [systemd-analyze]: https://man.archlinux.org/man/systemd-analyze.1
+[awk]: https://www.gnu.org/software/gawk/

--- a/lua/lint/linters/awk.lua
+++ b/lua/lint/linters/awk.lua
@@ -1,4 +1,4 @@
-local pattern = ".-:(%d+):.-[%s%S]*%^%s*(%S.*)"
+local pattern = ":(%d+):.-\n*%^%s*(%S.*)"
 local groups = { "lnum", "message" }
 
 return {
@@ -8,7 +8,7 @@ return {
   stream = "stderr",
   ignore_exitcode = true,
   parser = require("lint.parser").from_pattern(pattern, groups, nil, {
-    ["source"] = "awk",
-    ["severity"] = vim.diagnostic.severity.ERROR,
+    source = "awk",
+    severity = vim.diagnostic.severity.ERROR,
   }),
 }

--- a/lua/lint/linters/awk.lua
+++ b/lua/lint/linters/awk.lua
@@ -1,0 +1,14 @@
+local pattern = ".-:(%d+):.-[%s%S]*%^%s*(%S.*)"
+local groups = { "lnum", "message" }
+
+return {
+  cmd = "awk",
+  stdin = true,
+  args = { "-f-", "-L" },
+  stream = "stderr",
+  ignore_exitcode = true,
+  parser = require("lint.parser").from_pattern(pattern, groups, nil, {
+    ["source"] = "awk",
+    ["severity"] = vim.diagnostic.severity.ERROR,
+  }),
+}


### PR DESCRIPTION
This PR adds a awk linter using (g)awk. I'm unsure if it instead should be called gawk, seeing as there are quite a few different AWK interpreters, and it's the gnu one that provides this linting functionality. I don't know about all the others. I saw [conform.nvim](https://github.com/stevearc/conform.nvim) use awk so I did as well.

Let me know what you think.
