### PR TITLE
fix: default values for missing fields

### DIFF
--- a/lua/lint/linters/phpinsights.lua
+++ b/lua/lint/linters/phpinsights.lua
@@ -25,9 +25,9 @@ return {
     for insight, severity in pairs(insight_to_severity) do
       for _, message in ipairs(json[insight] or {}) do
           table.insert(diagnostics, {
-            lnum = message.line - 1,
+            lnum = (message.line or 1) - 1,
             col = 0,
-            message = message.message,
+            message = message.message or message.title,
             severity = severity,
             source = bin,
           })


### PR DESCRIPTION
Architecture diagnostics lack the line number and the message field is named title.

closes #624 