### PR TITLE
fix: format error in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Configure the linters you want to run per file type. For example:
 
 ```lua
 require('lint').linters_by_ft = {
-  markdown = {'vale',}
+  markdown = {'vale'},
 }
 ```
 


### PR DESCRIPTION
The example config in Usage section has a format error.

This
```lua
  markdown = {'value',}
```
should be
```lua
  markdown = {'value'},
```