### PR TITLE
feat: support markdownlint with standard input

### DIFF
--- a/lua/lint/linters/markdownlint.lua
+++ b/lua/lint/linters/markdownlint.lua
@@ -1,11 +1,13 @@
-local efm = '%f:%l:%c %m,%f:%l %m'
-local is_windows = vim.loop.os_uname().version:match('Windows')
+local efm = "stdin:%l:%c %m,stdin:%l %m"
+local is_windows = vim.loop.os_uname().version:match("Windows")
 return {
-    cmd = is_windows and 'markdownlint.cmd' or 'markdownlint',
-    ignore_exitcode = true,
-    stream = 'stderr',
-    parser =  require('lint.parser').from_errorformat(efm, {
-        source = 'markdownlint',
-        severity = vim.diagnostic.severity.WARN,
-    })
+  cmd = is_windows and "markdownlint.cmd" or "markdownlint",
+  stdin = true,
+  args = { "--stdin" },
+  ignore_exitcode = true,
+  stream = "stderr",
+  parser = require("lint.parser").from_errorformat(efm, {
+    source = "markdownlint",
+    severity = vim.diagnostic.severity.WARN,
+  }),
 }

--- a/tests/markdownlint_spec.lua
+++ b/tests/markdownlint_spec.lua
@@ -1,33 +1,33 @@
-describe('linter.markdownlint', function()
-  it('can parse the output', function()
-    local parser = require('lint.linters.markdownlint').parser
+describe("linter.markdownlint", function()
+  it("can parse the output", function()
+    local parser = require("lint.linters.markdownlint").parser
     local result = parser([[
-README.md:35 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## What's in this repo?"]
-README.md:36 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- `dotfiles`"]
-README.md:47:81 MD013/line-length Line length [Expected: 80; Actual: 114]
-README.md:55:81 MD013/line-length Line length [Expected: 80; Actual: 244]
+stdin:35 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## What's in this repo?"]
+stdin:36 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- `dotfiles`"]
+stdin:47:81 MD013/line-length Line length [Expected: 80; Actual: 114]
+stdin:55:81 MD013/line-length Line length [Expected: 80; Actual: 244]
 ]])
-  assert.are.same(4, #result)
-  local expected = {
-    source = 'markdownlint',
-    message = 'MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## What\'s in this repo?"]',
-    lnum = 34,
-    col = 0,
-    end_lnum = 34,
-    end_col = 0,
-    severity = vim.diagnostic.severity.WARN,
-  }
-  assert.are.same(expected, result[1])
+    assert.are.same(4, #result)
+    local expected = {
+      source = "markdownlint",
+      message = 'MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## What\'s in this repo?"]',
+      lnum = 34,
+      col = 0,
+      end_lnum = 34,
+      end_col = 0,
+      severity = vim.diagnostic.severity.WARN,
+    }
+    assert.are.same(expected, result[1])
 
-  expected = {
-    source = 'markdownlint',
-    message = 'MD013/line-length Line length [Expected: 80; Actual: 114]',
-    lnum = 46,
-    col = 80,
-    end_lnum = 46,
-    end_col = 80,
-    severity = vim.diagnostic.severity.WARN,
-  }
-  assert.are.same(expected, result[3])
+    expected = {
+      source = "markdownlint",
+      message = "MD013/line-length Line length [Expected: 80; Actual: 114]",
+      lnum = 46,
+      col = 80,
+      end_lnum = 46,
+      end_col = 80,
+      severity = vim.diagnostic.severity.WARN,
+    }
+    assert.are.same(expected, result[3])
   end)
 end)


### PR DESCRIPTION
`markdownlint` supports standard input with option `--stdin`. Enabling standard input can help neovim update diagnostics for `InsertLeave` and `TextChanged` events.
