### PR TITLE
fix(verilator): added file group

### DIFF
--- a/lua/lint/linters/verilator.lua
+++ b/lua/lint/linters/verilator.lua
@@ -1,6 +1,6 @@
-local pattern = "^%%(.-)-?(%u*): .-:(%d+):(%d+): (.*)"
+local pattern = "^%%(.-)-?(%u*): (.-):(%d+):(%d+): (.*)"
 
-local groups = { "severity", "code", "lnum", "col", "message" }
+local groups = { "severity", "code", "file", "lnum", "col", "message" }
 
 local severities = {
   ["Error"] = vim.diagnostic.severity.ERROR,

--- a/tests/verilator_spec.lua
+++ b/tests/verilator_spec.lua
@@ -1,6 +1,7 @@
 describe('linter.verilator', function()
   it('can parse the output', function()
     local parser = require('lint.linters.verilator').parser
+    local bufnr = vim.uri_to_bufnr('file:///t.v')
     local result = parser([[
 %Warning-DECLFILENAME: t.v:24:8: Filename 't' does not match MODULE name: 'uart'
     24 | module uart
@@ -30,7 +31,7 @@ describe('linter.verilator', function()
     64 |  uart_tx
       |  ^~~~~~~
 %Error: Exiting due to 3 error(s), 3 warning(s)
-    ]], vim.api.nvim_get_current_buf())
+    ]], bufnr, '')
     assert.are.same(6, #result)
 
     local expected = {
@@ -66,5 +67,5 @@ describe('linter.verilator', function()
       },
     }
     assert.are.same(expected, result[5])
-        end)
-      end)
+  end)
+end)


### PR DESCRIPTION
Issue: Earlier diagnostics of all files(in the included directories) for a line number was shown in the currently open buffer. Fix: Now the behaviour is normal since nvim-lint can now detect the file name and will show diagnostics relevant to the current buffer only.