### PR TITLE
Add doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
Plugin managers generate tag files for the help-page bundled with nvim-lint. But this makes the plugins directory appear as "modified" in git status. It can be annoying when installing plugins as submodules, because now everything is "modified".