### PR TITLE
Allow linter's cwd to be specifed as function

### DIFF
--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -315,6 +315,9 @@ local function with_cwd(cwd, fn, ...)
   if curcwd == cwd then
     return fn(...)
   else
+    if type(cwd) == 'function' then
+      cwd = cwd()
+    end
     local mods = { noautocmd = true }
     vim.cmd.cd({cwd, mods = mods})
     local ok, result = pcall(fn, ...)


### PR DESCRIPTION
### Why this change?

When I set per-linter `cwd` I'm noticing that the value gets evaluated too early, when Neovim is launched while the lazy package manager is assembling all plugins' `opts`. This becomes problematic as I have some logic that needs to find a certain configuration file in order to give me back the desired path for the `cwd`. And it's also only applicable if I open a certain file type in a neovim buffer.

So, I'd like to instead provide `cwd` as a function, so that it will be called when actually performing the linting and only for relevant file types.

To better explain what I mean, I define my nvim-lint linters in per-language lua config files, and then I have a main nvim-lint lua file which merges all the opts before actually passing the opts into nvim-lint:

* python: https://github.com/fredrikaverpil/dotfiles/blob/21b3ff2f2afad620ffc8e6060d1f46f8a9dc1638/nvim-fredrik/lua/lang/python.lua#L177
* go: https://github.com/fredrikaverpil/dotfiles/blob/65a48180f2e2543eb476cba0094f7ef1cc174c4e/nvim-fredrik/lua/lang/go.lua#L62
* protobuf: https://github.com/fredrikaverpil/dotfiles/blob/91213fc3050dab919645714479c771c0b9550f65/nvim-fredrik/lua/lang/protobuf.lua#L68
* lint.lua assembling all linters: https://github.com/fredrikaverpil/dotfiles/blob/21b3ff2f2afad620ffc8e6060d1f46f8a9dc1638/nvim-fredrik/lua/plugins/lint.lua#L16

You can see how I need to specify the `cwd` for protobuf and I don't want that logic to run for any other linter.

### What was changed?

- Add the capability to handle a linter's `opts.cwd` in case a function was passed in.

### Notes

- Should probably add a note about this in the docs txt and/or README?
- I'm a little confused by https://github.com/mfussenegger/nvim-lint/issues/646 which seems to indicate setting the `cwd` per linter is not even possible (or desired)... It feels like I've misunderstood something quite fundamental. But the docs mention it [here](https://github.com/mfussenegger/nvim-lint/blob/27f44d1cc3d733a38a736acb902f94879d99c76c/doc/lint.txt#L84) and `uv.spawn` does receive the `cwd` as part of the `linter_opts` passed into it ([here](https://github.com/mfussenegger/nvim-lint/blob/968a35d54b3a4c1ce66609cf80b14d4ae44fe77f/lua/lint.lua#L366)). It _seems_ to me I can set `cwd` per-linter just fine... and this PR change _seems_ to also work... 🤔 