### PR TITLE
feat: capture mypy error codes

### DIFF
--- a/lua/lint/linters/mypy.lua
+++ b/lua/lint/linters/mypy.lua
@@ -1,6 +1,6 @@
 -- path/to/file:line:col: severity: message
-local pattern = '([^:]+):(%d+):(%d+):(%d+):(%d+): (%a+): (.*)'
-local groups = { 'file', 'lnum', 'col', 'end_lnum', 'end_col', 'severity', 'message' }
+local pattern = '([^:]+):(%d+):(%d+):(%d+):(%d+): (%a+): (.*) %[(%a[%a-]+)%]'
+local groups = { 'file', 'lnum', 'col', 'end_lnum', 'end_col', 'severity', 'message', 'code' }
 local severities = {
   error = vim.diagnostic.severity.ERROR,
   warning = vim.diagnostic.severity.WARN,
@@ -14,7 +14,6 @@ return {
   args = {
     '--show-column-numbers',
     '--show-error-end',
-    '--hide-error-codes',
     '--hide-error-context',
     '--no-color-output',
     '--no-error-summary',

--- a/spec/mypy_spec.lua
+++ b/spec/mypy_spec.lua
@@ -3,8 +3,8 @@ describe('linter.mypy', function()
     local parser = require('lint.linters.mypy').parser
     local bufnr = vim.uri_to_bufnr('file:///foo.py')
     local output = [[
-/foo.py:10:15:10:20: error: Incompatible return value type (got "str", expected "bool")
-/foo.py:20:25:20:30: error: Argument 1 to "foo" has incompatible type "str"; expected "int"
+/foo.py:10:15:10:20: error: Incompatible return value type (got "str", expected "bool") [return-value]
+/foo.py:20:25:20:30: error: Argument 1 to "foo" has incompatible type "str"; expected "int" [arg-type]
 ]]
     local result = parser(output, bufnr)
 
@@ -13,22 +13,34 @@ describe('linter.mypy', function()
     local expected_error = {
       source = 'mypy',
       message = 'Incompatible return value type (got "str", expected "bool")',
+      code = 'return-value',
       lnum = 9,
       col = 14,
       end_lnum = 9,
       end_col = 20,
       severity = vim.diagnostic.severity.ERROR,
+      user_data = {
+        lsp = {
+          code = 'return-value'
+        }
+      }
     }
     assert.are.same(expected_error, result[1])
 
     local expected_warning = {
       source = 'mypy',
       message = 'Argument 1 to "foo" has incompatible type "str"; expected "int"',
+      code = 'arg-type',
       lnum = 19,
       col = 24,
       end_lnum = 19,
       end_col = 30,
       severity = vim.diagnostic.severity.ERROR,
+      user_data = {
+        lsp = {
+          code = 'arg-type'
+        }
+      }
     }
     assert.are.same(expected_warning, result[2])
   end)


### PR DESCRIPTION
Capturing mypy [error codes](https://mypy.readthedocs.io/en/stable/error_code_list.html) to use in diagnostics.

![image](https://github.com/user-attachments/assets/fe5e1772-f97a-4feb-b0c4-bbd16f6405ff)
