### PR TITLE
Fix absoulte path recognition on windows in parser

### DIFF
--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -93,7 +93,7 @@ function M.from_pattern(pattern, groups, severity_map, defaults, opts)
     end
     if captures.file then
       local path
-      if vim.startswith(captures.file, '/') then
+      if (string.match(captures.file, '^%w:') or vim.startswith(captures.file, '/')) then
         path = captures.file
       else
         path = vim.fn.simplify(linter_cwd .. '/' .. captures.file)


### PR DESCRIPTION
As the absolute Path recognition only works for linux style paths in the match function of the parser. Linter that output absolute paths were not working on windows.