### PR TITLE
chore: fix stream type

### DIFF
--- a/doc/lint.txt
+++ b/doc/lint.txt
@@ -78,7 +78,7 @@ lint.Linter                                                        *lint.Linter*
         {stdin?}            (boolean)                   send content via stdin. Defaults to false
         {append_fname?}     (boolean)                   Automatically add the current file name to the commands arguments.
                                                         Only has an effect if stdin is false
-        {stream}            ("stdout"|"stderr"|"both")  result stream. Defaults to stdout
+        {stream?}           ("stdout"|"stderr"|"both")  result stream. Defaults to stdout
         {ignore_exitcode?}  (boolean)                   Declares if exit code != 1 should be ignored or result in a warning. Defaults to false
         {env?}              (table)
         {cwd?}              (string)

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -158,7 +158,7 @@ M.linters = setmetatable({}, {
 ---Automatically add the current file name to the commands arguments.
 ---Only has an effect if stdin is false
 ---@field append_fname? boolean
----@field stream? "stdout"|"stderr"|"both" result stream. Defaults to stdout
+---@field stream? 'stdout'|'stderr'|'both' result stream. Defaults to stdout
 ---Declares if exit code != 1 should be ignored or result in a warning. Defaults to false
 ---@field ignore_exitcode? boolean
 ---@field env? table

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -158,7 +158,7 @@ M.linters = setmetatable({}, {
 ---Automatically add the current file name to the commands arguments.
 ---Only has an effect if stdin is false
 ---@field append_fname? boolean
----@field stream '"stdout"|"stderr"|"both"' result stream. Defaults to stdout
+---@field stream? "stdout"|"stderr"|"both" result stream. Defaults to stdout
 ---Declares if exit code != 1 should be ignored or result in a warning. Defaults to false
 ---@field ignore_exitcode? boolean
 ---@field env? table


### PR DESCRIPTION
The luadoc says that the stream field is optional, and the usage reflects that. I made the type optional. Also setting a particular stream value doesn't seem to work for lua_ls so I corrected the union type.
