### PR TITLE
fix(protolint): check for vim.NIL

### DIFF
--- a/lua/lint/linters/protolint.lua
+++ b/lua/lint/linters/protolint.lua
@@ -12,7 +12,7 @@ return {
     end
     local json_output = vim.json.decode(output)
     local diagnostics = {}
-    if json_output.lints == nil then
+    if json_output.lints == nil or json_output.lints == vim.NIL then
       return diagnostics
     end
     for _, item in ipairs(json_output.lints) do


### PR DESCRIPTION
### Why this change?

After debugging an nvim-lint/protolint crash I got in a proto file, it turns out that the `json_output.lints` can be `vim.NIL` (not `nil`).

### What was changed?

Extend the nilcheck with checking for `vim.NIL`.
