### PR TITLE
Pass relative path to terraform validate instead of changing cwd

### DIFF
--- a/lua/lint/linters/terraform_validate.lua
+++ b/lua/lint/linters/terraform_validate.lua
@@ -7,7 +7,7 @@ local terraform_severity_to_diagnostic_severity = {
 return function()
   return {
     cmd = 'terraform',
-    args = { "validate", "-json", vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ":.:h") },
+    args = { 'validate', '-json', vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ':.:h') },
     append_fname = false,
     stdin = false,
     stream = 'both',

--- a/lua/lint/linters/terraform_validate.lua
+++ b/lua/lint/linters/terraform_validate.lua
@@ -7,12 +7,11 @@ local terraform_severity_to_diagnostic_severity = {
 return function()
   return {
     cmd = 'terraform',
-    args = { 'validate', '-json' },
+    args = { "validate", "-json", vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ":.:h") },
     append_fname = false,
     stdin = false,
     stream = 'both',
     ignore_exitcode = true,
-    cwd = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),
     parser = function(output, bufnr)
       local decoded = vim.json.decode(output) or {}
       local diagnostics = decoded['diagnostics'] or {}


### PR DESCRIPTION
`terraform validate` starts validation from the cwd (unless `-chdir` is used), when we want to validate just some file (actually directory as it cannot validate just one file), instead of changing cwd we have to pass it as an argument.