### PR TITLE
Update end_lnum and end_col for clj-kondo

### DIFF
--- a/lua/lint/linters/clj-kondo.lua
+++ b/lua/lint/linters/clj-kondo.lua
@@ -24,8 +24,8 @@ return {
       table.insert(diagnostics, {
         lnum = finding.row - 1,
         col = finding.col - 1,
-        end_lnum = finding.row - 1,
-        end_col = finding.col - 1,
+        end_lnum = (finding["end-row"] or finding.row) - 1,
+        end_col = (finding["end-col"] or finding.col) - 1,
         severity = assert(severities[finding.level], 'missing mapping for severity ' .. finding.level),
         message = finding.message,
       })


### PR DESCRIPTION
As the [documentation for `clj-kondo` specifies](https://github.com/clj-kondo/clj-kondo/blob/d7dff3762a7fad581da56d15b026f537e3623438/analysis/README.md#data), end-col and end-row are returned in some circumstances.
This patch will prefer end-col and end-row, if they are returned. 
It enables underlining for many diagnostics.