### PR TITLE
Fix: Off-by-one Line/Column indexed from Hlint

### DIFF
--- a/lua/lint/linters/hlint.lua
+++ b/lua/lint/linters/hlint.lua
@@ -12,10 +12,10 @@ return {
     local items = #output > 0 and vim.json.decode(output) or {}
     for _, item in ipairs(items) do
       table.insert(diagnostics, {
-        lnum = item.startLine,
-        col = item.startColumn,
-        end_lnum = item.endLine,
-        end_col = item.endColumn,
+        lnum = item.startLine - 1,
+        col = item.startColumn - 1,
+        end_lnum = item.endLine - 1,
+        end_col = item.endColumn - 1,
         severity = severities[item.severity:lower()],
         source = "hlint",
         message = item.hint .. (item.to ~= vim.NIL and (": " .. item.to) or ""),

--- a/spec/hlint_spec.lua
+++ b/spec/hlint_spec.lua
@@ -11,10 +11,10 @@ describe("linter.hlint", function()
     ]])
     assert.are.same(#result, 1)
     local expected = {
-      lnum = 2,
-      col = 1,
-      end_lnum = 2,
-      end_col = 1,
+      lnum = 1,
+      col = 0,
+      end_lnum = 1,
+      end_col = 0,
       severity = vim.diagnostic.severity.ERROR,
       source = "hlint",
       message = "Parse error: possibly incorrect indentation or mismatched brackets",
@@ -34,10 +34,10 @@ describe("linter.hlint", function()
     ]])
     assert.are.same(#result, 1)
     local expected = {
-      lnum = 1,
-      col = 1,
-      end_lnum = 1,
-      end_col = 17,
+      lnum = 0,
+      col = 0,
+      end_lnum = 0,
+      end_col = 16,
       severity = vim.diagnostic.severity.WARN,
       source = "hlint",
       message = "Use concatMap: concatMap f x",


### PR DESCRIPTION
Hlint returns 1-indexed line and column numbers. However, `nvim-lint` uses indexes from 0. This causes Hlint's diagnostic to be reported on the wrong line/column

<details>
<summary>Example</summary>
<img width="412" alt="Screenshot 2024-12-14 at 12 17 14" src="https://github.com/user-attachments/assets/42c06674-81f6-493d-811c-b32b624d85cf" />
</details>

<details>
<summary>Proof that Hlint reports 1-indexed line numbers</summary>
Here is the output of Hlint:

```json
// hlint --json a.hs | jq
[
  {
    "module": [
      "Main"
    ],
    "decl": [
      "a"
    ],
    "severity": "Warning",
    "hint": "Redundant bracket",
    "file": "a.hs",
    "startLine": 1,
    "startColumn": 5,
    "endLine": 1,
    "endColumn": 8,
    "from": "(1)",
    "to": "1",
    "note": [],
    "refactorings": "[Replace {rtype = Expr, pos = SrcSpan {startLine = 1, startCol = 5, endLine = 1, endCol = 8}, subts = [(\"x\",SrcSpan {startLine = 1, startCol = 6, endLine = 1, endCol = 7})], orig = \"x\"}]"
  }
]
```
</details>

This PR fixes this issue and updates the tests accordingly.

Thanks for the plugin :)