### PR TITLE
Add dmypy linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Other dedicated linters that are built-in are:
 | [dash][dash]                           | `dash`                 |
 | [deadnix][deadnix]                     | `deadnix`              |
 | [deno][deno]                           | `deno`                 |
+| [dmypy][dmypy]                         | `dmypy`                |
 | [DirectX Shader Compiler][dxc]         | `dxc`                  |
 | [djlint][djlint]                       | `djlint`               |
 | [dotenv-linter][dotenv-linter]         | `dotenv_linter`        |
@@ -539,6 +540,7 @@ busted tests/
 [gdlint]: https://github.com/Scony/godot-gdscript-toolkit
 [rpm]: https://rpm.org
 [ec]: https://github.com/editorconfig-checker/editorconfig-checker
+[dmypy]: https://mypy.readthedocs.io/en/stable/mypy_daemon.html
 [deno]: https://github.com/denoland/deno
 [standardjs]: https://standardjs.com/
 [biomejs]: https://github.com/biomejs/biome

--- a/lua/lint/linters/dmypy.lua
+++ b/lua/lint/linters/dmypy.lua
@@ -1,0 +1,37 @@
+-- path/to/file:line:col: severity: message
+local pattern = '([^:]+):(%d+):(%d+):(%d+):(%d+): (%a+): (.*) %[(%a[%a-]+)%]'
+local groups = { 'file', 'lnum', 'col', 'end_lnum', 'end_col', 'severity', 'message', 'code' }
+local severities = {
+  error = vim.diagnostic.severity.ERROR,
+  warning = vim.diagnostic.severity.WARN,
+  note = vim.diagnostic.severity.HINT,
+}
+
+return {
+  cmd = 'dmypy',
+  stdin = false,
+  ignore_exitcode = true,
+  args = {
+    'run',
+    '--timeout',
+    '50000',
+    '--',
+    '--show-column-numbers',
+    '--show-error-end',
+    '--hide-error-context',
+    '--no-color-output',
+    '--no-error-summary',
+    '--no-pretty',
+    '--python-executable',
+    function()
+      return vim.fn.exepath 'python3' or vim.fn.exepath 'python'
+    end
+  },
+  parser = require('lint.parser').from_pattern(
+    pattern,
+    groups,
+    severities,
+    { ['source'] = 'dmypy' },
+    { end_col_offset = 0 }
+  ),
+}

--- a/spec/dmypy_spec.lua
+++ b/spec/dmypy_spec.lua
@@ -1,0 +1,47 @@
+describe('linter.dmypy', function()
+  it('can parse the output', function()
+    local parser = require('lint.linters.dmypy').parser
+    local bufnr = vim.uri_to_bufnr('file:///foo.py')
+    local output = [[
+/foo.py:10:15:10:20: error: Incompatible return value type (got "str", expected "bool") [return-value]
+/foo.py:20:25:20:30: error: Argument 1 to "foo" has incompatible type "str"; expected "int" [arg-type]
+]]
+    local result = parser(output, bufnr)
+
+    assert.are.same(2, #result)
+
+    local expected_error = {
+      source = 'dmypy',
+      message = 'Incompatible return value type (got "str", expected "bool")',
+      code = 'return-value',
+      lnum = 9,
+      col = 14,
+      end_lnum = 9,
+      end_col = 20,
+      severity = vim.diagnostic.severity.ERROR,
+      user_data = {
+        lsp = {
+          code = 'return-value'
+        }
+      }
+    }
+    assert.are.same(expected_error, result[1])
+
+    local expected_warning = {
+      source = 'dmypy',
+      message = 'Argument 1 to "foo" has incompatible type "str"; expected "int"',
+      code = 'arg-type',
+      lnum = 19,
+      col = 24,
+      end_lnum = 19,
+      end_col = 30,
+      severity = vim.diagnostic.severity.ERROR,
+      user_data = {
+        lsp = {
+          code = 'arg-type'
+        }
+      }
+    }
+    assert.are.same(expected_warning, result[2])
+  end)
+end)


### PR DESCRIPTION
Adds `dmypy` as a linter, which contains mostly the same interface as `mypy` but it is ran in a daemon process.
I've been using `dmypy` for a bit in my own setup as it has been working well.

I haven't been able to run the tests locally as I can't seems to get `busted` working.