### PR TITLE
fix(terraform_validate): pass `-chdir=` to `terraform` command

### DIFF
--- a/lua/lint/linters/terraform_validate.lua
+++ b/lua/lint/linters/terraform_validate.lua
@@ -7,7 +7,7 @@ local terraform_severity_to_diagnostic_severity = {
 return function()
   return {
     cmd = 'terraform',
-    args = { 'validate', '-json', vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ':.:h') },
+    args = { '-chdir=' .. vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ':.:h'), 'validate', '-json' },
     append_fname = false,
     stdin = false,
     stream = 'both',


### PR DESCRIPTION
This ensures `terraform validate` is aware of `.terraform/` and does not report false positives for missing  (uninstalled) modules.

More information in comment on PR that originally changed that: https://github.com/mfussenegger/nvim-lint/pull/694#issuecomment-2558669860.