### PR TITLE
fix(fish): allow an arbitrary word before line number

### DIFF
--- a/lua/lint/linters/fish.lua
+++ b/lua/lint/linters/fish.lua
@@ -1,4 +1,4 @@
-local efm = "%E%f (line %l): %m,%C%p^,%C%.%#"
+local efm = "%E%f (%[%^ ]%# %l): %m,%C%p^,%C%.%#"
 return {
   cmd = "fish",
   args = { "--no-execute" },


### PR DESCRIPTION
The error message generated by `fish --no-execute` varies by locale. For instance:

```sh
$ cat test.fish
|
$ LANG=C fish --no-execute test.fish
test.fish (line 1): Expected a string, but found a pipe
|
^
warning: Error while reading file test.fish

$ LANG=pl_PL.UTF-8 fish --no-execute test.fish
test.fish (linia 1): Expected a string, but found a pipe
|
^
warning: Wystąpił błąd podczas odczytywania pliku test.fish

```

This means that hardcoding the word `line` into the errorformat is too strong. This commit replaces it with an arbitrary string not containing a space character (`%[%^ ]%#`).

Fixes #708.