### PR TITLE
fix(cfn-lint): ignore exit code

### DIFF
--- a/lua/lint/linters/cfn_lint.lua
+++ b/lua/lint/linters/cfn_lint.lua
@@ -9,5 +9,6 @@ return {
   cmd = "cfn-lint",
   args = { "--format", "parseable" },
   stdin = false,
+  ignore_exitcode = true,
   parser = require("lint.parser").from_pattern(pattern, groups, severity_map, { ["source"] = "cfn-lint" }),
 }


### PR DESCRIPTION
This ignores the exit code of cfn-lint. cfn-lint only uses it to communicate
what it found.
