### PR TITLE
Parse GHDL diagnostic severity

### DIFF
--- a/lua/lint/linters/ghdl.lua
+++ b/lua/lint/linters/ghdl.lua
@@ -1,7 +1,8 @@
-local pattern = "([^:]+):(%d+):(%d+):(.+)"
-local groups = { "file", "lnum", "col", "message" }
+local pattern = "([^:]+):(%d+):(%d+):([^:]+):(.+)"
+local groups = { "file", "lnum", "col", "severity", "message" }
 local severity_map = {
   ["error"] = vim.diagnostic.severity.ERROR,
+  ["warning"] = vim.diagnostic.severity.WARN,
 }
 
 return {


### PR DESCRIPTION
GHDL provides the severity of its diagnostics. For example:

```
test/tb_lfsr.vhd:7:20:error: no declaration for "std_logic"
    signal clk   : std_logic;
                   ^
test/tb_lfsr.vhd:8:20:error: no declaration for "std_logic"
    signal arst  : std_logic;
                   ^
test/tb_lfsr.vhd:9:20:error: no declaration for "std_logic_vector"
    signal value : std_logic_vector(15 downto 0);
                   ^
test/tb_lfsr.vhd:7:12:warning: signal "clk" is never referenced [-Wunused]
    signal clk   : std_logic;
           ^
test/tb_lfsr.vhd:8:12:warning: signal "arst" is never referenced [-Wunused]
    signal arst  : std_logic;
           ^
test/tb_lfsr.vhd:9:12:warning: signal "value" is never referenced [-Wunused]
    signal value : std_logic_vector(15 downto 0);
```

I don't know if it will ever produce any other kind of severity. But these two seem to be the most common.