### PR TITLE
ghdl: trim whitespace

### DIFF
--- a/lua/lint/linters/ghdl.lua
+++ b/lua/lint/linters/ghdl.lua
@@ -1,4 +1,4 @@
-local pattern = "([^:]+):(%d+):(%d+):([^:]+):(.+)"
+local pattern = "([^:]+):(%d+):(%d+):(%l+):%s*(.+)"
 local groups = { "file", "lnum", "col", "severity", "message" }
 local severity_map = {
   ["error"] = vim.diagnostic.severity.ERROR,


### PR DESCRIPTION
Before:

```
ghdl:  no declaration for "unsigned"
```

After:

```
ghdl: no declaration for "unsigned"
```

Also, use `(%l+)` instead of `([^:]+)` as severity seems to be always lowercase
`error` or `warning`.