### PR TITLE
mypy: set stream to "both"

### DIFF
--- a/lua/lint/linters/mypy.lua
+++ b/lua/lint/linters/mypy.lua
@@ -10,6 +10,7 @@ local severities = {
 return {
   cmd = 'mypy',
   stdin = false,
+  stream = "both",
   ignore_exitcode = true,
   args = {
     '--show-column-numbers',


### PR DESCRIPTION
mypy outputs the errors to `stdout` by default but the following
configuration options can change the behavior to output them on
`stderr`:

install_types = "True"
non_interactive = "True"

`stream = "both"` should handle both cases.

Closes https://github.com/mfussenegger/nvim-lint/issues/700
