### PR TITLE
feat: added sqruff

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Other dedicated linters that are built-in are:
 | [Spectral][spectral]                   | `spectral`             |
 | [sphinx-lint][sphinx-lint]             | `sphinx-lint`          |
 | [sqlfluff][sqlfluff]                   | `sqlfluff`             |
+| [sqruff][sqruff]                       | `sqruff`               |
 | [standardjs][standardjs]               | `standardjs`           |
 | [StandardRB][27]                       | `standardrb`           |
 | [statix check][33]                     | `statix`               |
@@ -529,6 +530,7 @@ busted tests/
 [cue]: https://github.com/cue-lang/cue
 [curlylint]: https://www.curlylint.org/
 [sqlfluff]: https://github.com/sqlfluff/sqlfluff
+[sqruff]: https://github.com/quarylabs/sqruff
 [verilator]: https://verilator.org/guide/latest/
 [actionlint]: https://github.com/rhysd/actionlint
 [buf_lint]: https://github.com/bufbuild/buf

--- a/lua/lint/linters/sqruff.lua
+++ b/lua/lint/linters/sqruff.lua
@@ -5,6 +5,7 @@ local severities = {
 
 return {
   cmd = "sqruff",
+  stdin = true,
   args = {
     "lint",
     "--format=json",

--- a/lua/lint/linters/sqruff.lua
+++ b/lua/lint/linters/sqruff.lua
@@ -29,7 +29,7 @@ return {
         col = msg.range.start.character - 1,
         end_col = msg.range["end"].character - 1,
         message = msg.message,
-        code = msg.source, -- TODO: https://github.com/quarylabs/sqruff/issues/1219
+        -- code not provided: https://github.com/quarylabs/sqruff/issues/1219
         source = msg.source,
         severity = assert(severities[msg.severity], "missing mapping for severity " .. msg.severity),
       })

--- a/lua/lint/linters/sqruff.lua
+++ b/lua/lint/linters/sqruff.lua
@@ -1,0 +1,43 @@
+local severities = {
+  Error = vim.diagnostic.severity.ERROR,
+  Warning = vim.diagnostic.severity.WARN,
+}
+
+return {
+  cmd = "sqruff",
+  args = {
+    "lint",
+    "--format=json",
+    "-",
+  },
+  ignore_exitcode = true,
+  parser = function(output, _)
+    if vim.trim(output) == "" or output == nil then
+      return {}
+    end
+
+    if not vim.startswith(output, "{") then
+      vim.notify(output)
+      return {}
+    end
+
+    local decoded = vim.json.decode(output)
+    local diagnostics = {}
+    local messages = decoded["<string>"]
+
+    for _, msg in ipairs(messages or {}) do
+      table.insert(diagnostics, {
+        lnum = msg.range.start.line - 1,
+        end_lnum = msg.range["end"].line - 1,
+        col = msg.range.start.character - 1,
+        end_col = msg.range["end"].character - 1,
+        message = msg.message,
+        code = msg.source, -- TODO: https://github.com/quarylabs/sqruff/issues/1219
+        source = msg.source,
+        severity = assert(severities[msg.severity], "missing mapping for severity " .. msg.severity),
+      })
+    end
+
+    return diagnostics
+  end,
+}

--- a/lua/lint/linters/sqruff.lua
+++ b/lua/lint/linters/sqruff.lua
@@ -17,10 +17,6 @@ return {
       return {}
     end
 
-    if not vim.startswith(output, "{") then
-      vim.notify(output)
-      return {}
-    end
 
     local decoded = vim.json.decode(output)
     local diagnostics = {}


### PR DESCRIPTION
Added [sqruff](https://github.com/quarylabs/sqruff) to the list of available linters (a new tool inspired by Python's `ruff` and `sqlfluff`)

I've added with stdin support + json parsing; though their JSON-format output lacks the error codes (I made an issue: https://github.com/quarylabs/sqruff/issues/1219)

This was heavily inspired by the `phpcs`-implementation :-)

Let me know if I can improve it somehow