### PR TITLE
feat(sqruff): include error code in diagnostic

### DIFF
--- a/lua/lint/linters/sqruff.lua
+++ b/lua/lint/linters/sqruff.lua
@@ -17,7 +17,6 @@ return {
       return {}
     end
 
-
     local decoded = vim.json.decode(output)
     local diagnostics = {}
     local messages = decoded["<string>"]
@@ -29,7 +28,7 @@ return {
         col = msg.range.start.character - 1,
         end_col = msg.range["end"].character - 1,
         message = msg.message,
-        -- code not provided: https://github.com/quarylabs/sqruff/issues/1219
+        code = msg.code,
         source = msg.source,
         severity = assert(severities[msg.severity], "missing mapping for severity " .. msg.severity),
       })


### PR DESCRIPTION
It was fixed rather quickly upstream:
![image](https://github.com/user-attachments/assets/6770af06-9bce-44cc-9b27-23df90cc5fd7)

Want me to provide a backwards compatible `code = msg.code or nil` thing?

Ref: https://github.com/mfussenegger/nvim-lint/pull/728