### PR TITLE
golangci-lint: handle relative paths while parsing (#730)

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -34,7 +34,7 @@ return {
     for _, item in ipairs(decoded["Issues"]) do
       local curfile = vim.api.nvim_buf_get_name(bufnr)
       local lintedfile = cwd .. "/" .. item.Pos.Filename
-      if curfile == lintedfile then
+      if vim.fn.fnamemodify(curfile, ":p") == vim.fn.fnamemodify(lintedfile, ":p") then
         -- only publish if those are the current file diagnostics
         local sv = severities[item.Severity] or severities.warning
         table.insert(diagnostics, {


### PR DESCRIPTION
Compare absolute paths when determining filename to buffer matching