### PR TITLE
golangci-lint: do not exit error when finding lint

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -12,6 +12,7 @@ return {
     'run',
     '--out-format',
     'json',
+    '--issues-exit-code=0',
     '--show-stats=false',
     '--print-issued-lines=false',
     '--print-linter-name=false',
@@ -20,7 +21,6 @@ return {
     end
   },
   stream = 'stdout',
-  ignore_exitcode = true,
   parser = function(output, bufnr, cwd)
     if output == '' then
       return {}


### PR DESCRIPTION
Add arg to golangci-lint to not error exit when finding lint.

This allows error exit code to indicate failure to run the linter itself, update the linter config to not ignore error exit