### PR TITLE
fix: do not block UI when cancelling lint

### DIFF
--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -284,16 +284,15 @@ function LintProc:cancel()
   -- This is mostly useful for when `cmd` is a script with a shebang.
   handle:kill('sigint')
 
-  vim.wait(10000, function()
-    return handle:is_closing() or false
-  end)
+  vim.defer_fn(function()
+    if not handle:is_closing() then
+      -- 'sigint' didn't work, hit it with a 'sigkill'.
+      -- This should also kill any attached child processes since
+      -- handle is a process group leader (due to it being detached).
+      handle:kill("sigkill")
+    end
+  end, 10000)
 
-  if not handle:is_closing() then
-    -- 'sigint' didn't work, hit it with a 'sigkill'.
-    -- This should also kill any attached child processes since
-    -- handle is a process group leader (due to it being detached).
-    handle:kill('sigkill')
-  end
 end
 
 


### PR DESCRIPTION
Stole this contribution from [this PR](https://github.com/mfussenegger/nvim-lint/pull/688) since I do not have permissions to push to that branch and do not wish to continue maintaining my fork with this change. Minimized the contribution so that we only do the `vim.defer_fn` instead of `vim.wait` to remove the complexity of handling orphaned processes. As a side note, the handling of the orphaned processes on `VimLeavePre` caused my editor to freeze when exiting, so the change was not desirable for me anyways.
