### PR TITLE
fix(eslint): use 'npx eslint' when local binary is missing

### DIFF
--- a/lua/lint/linters/eslint.lua
+++ b/lua/lint/linters/eslint.lua
@@ -7,7 +7,7 @@ local severities = {
 return {
   cmd = function()
     local local_binary = vim.fn.fnamemodify('./node_modules/.bin/' .. binary_name, ':p')
-    return vim.loop.fs_stat(local_binary) and local_binary or binary_name
+    return vim.loop.fs_stat(local_binary) and local_binary or "npx " .. binary_name
   end,
   args = {
     '--format',


### PR DESCRIPTION
Fixes #747
Resolves #747
Closes #747

### Description
This fixes an issue where `nvim-lint` fails to find ESLint if it's not installed globally.
- Previously, the command used `"eslint"`, which fails if it's not in `PATH`.
- Now, it falls back to `"npx eslint"`, which correctly finds either the local or global version.

### Why This Fix?
- `npx eslint` works even if `eslint` is not globally installed.
- This prevents silent failures and makes `nvim-lint` more reliable.