### PR TITLE
fix(tflint): match path when .tf file is not in current dir

### DIFF
--- a/lua/lint/linters/tflint.lua
+++ b/lua/lint/linters/tflint.lua
@@ -6,7 +6,7 @@ local terraform_severity_to_diagnostic_severity = {
 
 return {
   cmd = "tflint",
-  args = {"--format=json"},
+  args = {"--format=json", "--recursive"},
   append_fname = false,
   stdin = false,
   ignore_exitcode = true,
@@ -14,7 +14,7 @@ return {
     local decoded = vim.json.decode(output) or {}
     local issues = decoded["issues"] or {}
     local diagnostics = {}
-    local buf_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t")
+    local buf_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":.")
 
     for _, issue in ipairs(issues) do
       if issue.range.filename == buf_path then

--- a/spec/tflint_spec.lua
+++ b/spec/tflint_spec.lua
@@ -3,7 +3,7 @@ describe('linter.tflint', function()
     local parser = require('lint.linters.tflint').parser
     local bufnr = vim.uri_to_bufnr('file:///main.tf')
     local result = parser(
-      [[{"issues":[{"rule":{"name":"terraform_required_providers","severity":"warning","link":"https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md"},"message":"Missing version constraint for provider \"aws\" in \"required_providers\"","range":{"filename":"main.tf","start":{"line":19,"column":1},"end":{"line":19,"column":15}},"callers":[]}],"errors":[]}]],
+      [[{"issues":[{"rule":{"name":"terraform_required_providers","severity":"warning","link":"https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md"},"message":"Missing version constraint for provider \"aws\" in \"required_providers\"","range":{"filename":"/main.tf","start":{"line":19,"column":1},"end":{"line":19,"column":15}},"callers":[]}],"errors":[]}]],
       bufnr
     )
     assert.are.same(1, #result)


### PR DESCRIPTION
# What
* use ":." instead of ":t" to obtain relative file name.
* add "--recursive" to default args

# Why
When using tools such as [terragrunt](https://terragrunt.gruntwork.io/) my repo consists of both Terraform modules and .hcl files with env-specific configurations. i.e

```
├── live
│   └── dev
│       ├── rds
│           └── terragrunt.hcl
├── modules
│   ├── rds
│   │   ├── main.tf
│   │   ├── outputs.tf
│   │   ├── README.md
│   │   └── variables.tf
```

* If I open my nvim at the root of the project `tflint` won't find any files without `--recursive` or `--chdir=modules/rds` flags.
* While using either of flags `tflint` returns paths that are relative to current dir.

### Sample tflint output:

```
❯ tflint --format=json --chdir="modules/rds" | jq
{
  "issues": [
    {
      "rule": {
        "name": "terraform_required_version",
        "severity": "warning",
        "link": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_required_version.md"
      },
      "message": "terraform \"required_version\" attribute is required",
      "range": {
        "filename": "modules/rds/main.tf",
        "start": {
          "line": 1,
          "column": 1
        },
        "end": {
          "line": 1,
          "column": 1
        }
      },
      "callers": []
    }
  ],
  "errors": []
}
```

### Open questions
Instead of using `--recursive` I considered sth along the lines of 
```lua
"--chdir=".. vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ":.:h")
```
but I'm not really sure if this will work 100% of the times.

