### PR TITLE
golangci-lint: normalize file paths when comparing to fix issue on win

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -33,8 +33,14 @@ return {
     local diagnostics = {}
     for _, item in ipairs(decoded["Issues"]) do
       local curfile = vim.api.nvim_buf_get_name(bufnr)
+      local curfile_abs = vim.fn.fnamemodify(curfile, ":p")
+      local curfile_norm = vim.fs.normalize(curfile_abs)
+
       local lintedfile = cwd .. "/" .. item.Pos.Filename
-      if vim.fn.fnamemodify(curfile, ":p") == vim.fn.fnamemodify(lintedfile, ":p") then
+      local lintedfile_abs = vim.fn.fnamemodify(lintedfile, ":p")
+      local lintedfile_norm = vim.fs.normalize(lintedfile_abs)
+
+      if curfile_norm == lintedfile_norm then
         -- only publish if those are the current file diagnostics
         local sv = severities[item.Severity] or severities.warning
         table.insert(diagnostics, {


### PR DESCRIPTION
Without this change nvim-lint wouldn't show any diagnostics on Windows for golangci-lint due to `lintedfile` being generated with a mix of `\` and `/`.  `vim.fs.normalize` ensure all the path separator on both side are the same.