### PR TITLE
feat: add support for twig-cs-fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Other dedicated linters that are built-in are:
 | [tlint][tlint]                         | `tlint`                |
 | [trivy][trivy]                         | `trivy`                |
 | [ts-standard][ts-standard]             | `ts-standard`          |
+| [twig-cs-fixer][twig-cs-fixer]         | `twig-cs-fixer`        |
 | [typos][typos]                         | `typos`                |
 | [Vala][vala-lint]                      | `vala_lint`            |
 | [Vale][8]                              | `vale`                 |
@@ -601,3 +602,4 @@ busted tests/
 [slang]: https://github.com/MikePopoloski/slang
 [zizmor]: https://github.com/woodruffw/zizmor
 [ts-standard]: https://github.com/standard/ts-standard
+[twig-cs-fixer]: https://github.com/VincentLanglet/Twig-CS-Fixer

--- a/lua/lint/linters/twig-cs-fixer.lua
+++ b/lua/lint/linters/twig-cs-fixer.lua
@@ -1,0 +1,23 @@
+local pattern = '^::(%a+) file=([^,]+),line=(%d+),col=(%d+)::(.+):%d+:%d+ %-%- (.+)'
+local groups = { 'severity', 'file', 'lnum', 'col', 'code', 'message' }
+local severity_map = {
+  ['error'] = vim.diagnostic.severity.ERROR,
+}
+
+local bin = 'twig-cs-fixer'
+return {
+  cmd = function ()
+    local local_bin = vim.fn.fnamemodify('vendor/bin/' .. bin, ':p')
+    return vim.loop.fs_stat(local_bin) and local_bin or bin
+  end,
+  stdin = false,
+  args = {
+    'lint',
+    '--report',
+    'github',
+    '--debug',
+  },
+  stream = 'stdout',
+  ignore_exitcode = true,
+  parser = require("lint.parser").from_pattern(pattern, groups, severity_map, { ["source"] = "twig-cs-fixer" }),
+}

--- a/spec/twig-cs-fixer_spec.lua
+++ b/spec/twig-cs-fixer_spec.lua
@@ -1,0 +1,60 @@
+describe('linter.twig-cs-fixer', function()
+  it("doesn't error on empty output", function()
+    local parser = require('lint.linters.twig-cs-fixer').parser
+    local bufnr = vim.api.nvim_get_current_buf()
+    parser('', bufnr, '')
+    parser('  ', bufnr, '')
+  end)
+
+  it('parses github output correctly', function()
+    local parser = require('lint.linters.twig-cs-fixer').parser
+    local bufnr = vim.uri_to_bufnr('file:///template.html.twig')
+    local result = parser([[
+::error file=template.html.twig,line=4,col=28::DelimiterSpacing.Before:4:28 -- Expecting 1 whitespace before "}}"; found 0.
+::error file=template.html.twig,line=3,col=75::PunctuationSpacing.After:3:75 -- Expecting 0 whitespace after "|"; found 1.
+::error file=template.html.twig,line=3,col=75::PunctuationSpacing.Before:3:75 -- Expecting 0 whitespace before "|"; found 1.
+]], bufnr, '')
+    assert.are.same(3, #result)
+
+    local expected = {
+      lnum = 3,
+      end_lnum = 3,
+      col = 27,
+      end_col = 27,
+      message = 'Expecting 1 whitespace before "}}"; found 0.',
+      code = 'DelimiterSpacing.Before',
+      source = 'twig-cs-fixer',
+      severity = vim.diagnostic.severity.ERROR,
+      user_data = { lsp = { code = 'DelimiterSpacing.Before' } },
+    }
+    assert.are.same(expected, result[1])
+
+    expected = {
+      lnum = 2,
+      end_lnum = 2,
+      col = 74,
+      end_col = 74,
+      message = 'Expecting 0 whitespace after "|"; found 1.',
+      code = 'PunctuationSpacing.After',
+      source = 'twig-cs-fixer',
+      severity = vim.diagnostic.severity.ERROR,
+      user_data = { lsp = { code = 'PunctuationSpacing.After' } },
+    }
+    assert.are.same(expected, result[2])
+
+    expected = {
+      lnum = 2,
+      end_lnum = 2,
+      col = 74,
+      end_col = 74,
+      message = 'Expecting 0 whitespace before "|"; found 1.',
+      code = 'PunctuationSpacing.Before',
+      source = 'twig-cs-fixer',
+      severity = vim.diagnostic.severity.ERROR,
+      user_data = { lsp = { code = 'PunctuationSpacing.Before' } },
+    }
+    assert.are.same(expected, result[3])
+
+  end)
+
+end)


### PR DESCRIPTION
Adds a linter for [`twig-cs-fixer`](https://github.com/VincentLanglet/Twig-CS-Fixer).

A similar tool to the already-supported [`twigcs`](https://github.com/friendsoftwig/twigcs), `twig-cs-fixer` now seems to be the linter/fixer [recommended by the Twig project](https://twig.symfony.com/doc/3.x/coding_standards.html).