### PR TITLE
docs: Add another linter customization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,11 @@ phpcs.args = {
   '--report=json',
   '-'
 }
+
+-- or prepend to existing arguments
+
+local mypy = require('lint').linters.mypy
+mypy.args = vim.list_extend({'--strict', '--allow-untyped-call'}, mypy.args)
 ```
 
 You can also post-process the diagnostics produced by a linter by wrapping it.

--- a/README.md
+++ b/README.md
@@ -386,7 +386,6 @@ phpcs.args = {
 }
 
 -- or prepend to existing arguments
-
 local mypy = require('lint').linters.mypy
 mypy.args = vim.list_extend({'--strict', '--allow-untyped-call'}, mypy.args)
 ```


### PR DESCRIPTION
It'd be helpful to demonstrate how to customize linters without overwriting their arguments.

I extended the linter customization snippet in the readme with an example of prepending to mypy's existing arguments.