### PR TITLE
Enable using the wrapper as a filter

### DIFF
--- a/lua/lint/util.lua
+++ b/lua/lint/util.lua
@@ -36,7 +36,7 @@ end
 --- ```
 ---
 ---@param linter lint.Linter|fun():lint.Linter
----@param map fun(d: vim.Diagnostic): vim.Diagnostic
+---@param map fun(d: vim.Diagnostic): vim.Diagnostic|nil
 ---@return lint.Linter|fun():lint.Linter
 function M.wrap(linter, map)
   local function _wrap(l, m)


### PR DESCRIPTION
Only a documentation/type change is needed. Setting a value in a table to nil already removes it, so no explicit filter is needed. This enables the usecase of removing a diagnostic entirely, rather than only modifying it.

For example:
```lua
lint.linters.languagetool =
    require("lint.util").wrap(lint.linters.languagetool, function (diagnostic)
        diagnostic.severity = vim.diagnostic.severity.HINT
        if diagnostic.message == "Possible typo: you repeated a whitespace" then
            return nil
        end
        return diagnostic
    end)
```