### PR TITLE
feat: add support for Vim Projectionist

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -1,0 +1,8 @@
+{
+    "lua/lint/linters/*.lua" : {
+        "alternate" : "spec/{}_spec.lua"
+    },
+    "spec/*_spec.lua" : {
+        "alternate" : "lua/lint/linters/{}.lua"
+    }
+}


### PR DESCRIPTION
Adds support for [Projectionist](https://github.com/tpope/vim-projectionist)'s Alternative Files feature.

This allows very fast switching between spec and implementation files (just hit `:A`)