### PR TITLE
feat: Set diagnostic code in PHPStan linter

### DIFF
--- a/lua/lint/linters/phpstan.lua
+++ b/lua/lint/linters/phpstan.lua
@@ -30,6 +30,7 @@ return {
         col = 0,
         message = message.message,
         source = bin,
+        code = message.identifier,
       })
     end
 

--- a/spec/phpstan_spec.lua
+++ b/spec/phpstan_spec.lua
@@ -29,7 +29,8 @@ describe('linter.phpstan', function()
             "message": "Property never read, only written.",
             "line": 6,
             "ignorable": true,
-            "tip": "See: https://phpstan.org/developing-extensions/always-read-written-properties"
+            "tip": "See: https://phpstan.org/developing-extensions/always-read-written-properties",
+            "identifier": "property.onlyWritten"
           }
         ]
       }
@@ -52,6 +53,7 @@ describe('linter.phpstan', function()
         lnum = 5,
         message = 'Property never read, only written.',
         source = 'phpstan',
+        code = 'property.onlyWritten',
       },
     }
 


### PR DESCRIPTION
Occassionally, one needs to ignore a rule as described at https://phpstan.org/user-guide/ignoring-errors

Having the name of the readily available is much better than having to search the web for it, as I otherwise find myself doing.