### PR TITLE
golangci-lint: clear alt output format paths to overwrite .golangci.yml

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -5,7 +5,7 @@ local severities = {
   convention = vim.diagnostic.severity.HINT,
 }
 
--- Gets the correct agruements to run based on the version of golangci-lint
+-- Gets the correct arguments to run based on the version of golangci-lint
 local getArgs = function()
   local ok, output = pcall(vim.fn.system, { 'golangci-lint', 'version' })
   if not ok then
@@ -32,6 +32,15 @@ local getArgs = function()
   return {
     'run',
     '--output.json.path=stdout',
+    -- Overwrite values possibly set in .golangci.yml
+    '--output.text.path=',
+    '--output.tab.path=',
+    '--output.html.path=',
+    '--output.checkstyle.path=',
+    '--output.code-climate.path=',
+    '--output.junit-xml.path=',
+    '--output.teamcity.path=',
+    '--output.sarif.path=',
     '--issues-exit-code=0',
     '--show-stats=false',
     function()


### PR DESCRIPTION
This is a fix for v2 of golangci-lint that clears out any alternative output paths that could be found in the config file.  This allows users to set whichever output format they'd prefer in the config file, while ensuring the linter is properly configured for use with this plugin. 

In v1, setting the output format would overwrite all other possibly set values in the config file, which is changed now in v2.

Discussion in #761 