### PR TITLE
feat(linters): add redocly

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Other dedicated linters that are built-in are:
 | [Pylint][15]                           | `pylint`               |
 | [pyproject-flake8][pflake8]            | `pflake8`              |
 | [quick-lint-js][quick-lint-js]         | `quick-lint-js`        |
+| [redocly][redocly]                     | `redolcy`              |
 | [regal][regal]                         | `regal`                |
 | [Revive][14]                           | `revive`               |
 | [rflint][rflint]                       | `rflint`               |
@@ -605,3 +606,4 @@ busted tests/
 [ts-standard]: https://github.com/standard/ts-standard
 [twig-cs-fixer]: https://github.com/VincentLanglet/Twig-CS-Fixer
 [fortitude]: https://github.com/PlasmaFAIR/fortitude
+[redocly]: https://redocly.com/docs/cli/commands/lint

--- a/lua/lint/linters/redocly.lua
+++ b/lua/lint/linters/redocly.lua
@@ -1,0 +1,27 @@
+local severities = {
+  critical = vim.diagnostic.severity.ERROR,
+  minor = vim.diagnostic.severity.WARN,
+}
+return {
+  cmd = "redocly",
+  stdin = false,
+  stream = "stdout",
+  ignore_exitcode = true,
+  args = { "lint", "--format", "codeclimate" },
+  parser = function(output, _)
+    local decoded = vim.json.decode(output)
+    local diagnostics = {}
+
+    for _, msg in ipairs(decoded or {}) do
+      table.insert(diagnostics, {
+        lnum = msg.location.lines.begin - 1,
+        col = 0,
+        message = msg.description,
+        source = "redocly",
+        severity = severities[msg.severity],
+      })
+    end
+
+    return diagnostics
+  end,
+}


### PR DESCRIPTION
`redocly lint` is an [OpenAPI linter](https://redocly.com/docs/cli/commands/lint). The best format I found is `codeclimate`, although it doesn't return anything about the location except the line number. For OpenAPI specs, it's usually thou enough.