### PR TITLE
[FIX] oelint-adv: fix parse pattern to support oelint-adv `[branch:XXX]`

### DIFF
--- a/lua/lint/linters/oelint-adv.lua
+++ b/lua/lint/linters/oelint-adv.lua
@@ -1,5 +1,5 @@
 -- path/to/file:line:severity:code:message
-local pattern = '([^:]+):(%d+):(%a+):(.+):(.+)'
+local pattern = '([^:]+):(%d+):(%a+):([^:]+):(.+)'
 local groups = { 'file', 'lnum', 'severity', 'code', 'message' }
 local severity_map = {
   ['error'] = vim.diagnostic.severity.ERROR,

--- a/spec/oelint-adv_spec.lua
+++ b/spec/oelint-adv_spec.lua
@@ -3,9 +3,9 @@ describe('linter.oelint-adv', function()
     local parser = require('lint.linters.oelint-adv').parser
     local bufnr = vim.uri_to_bufnr('file:///foo.bb')
     local result = parser([[
-/foo.bb:1:error:oelint.var.mandatoryvar.HOMEPAGE:Variable 'HOMEPAGE' should be set
-/foo.bb:1:info:oelint.var.suggestedvar.CVE_PRODUCT:Variable 'CVE_PRODUCT' should be set
-/foo.bb:2:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"'
+/foo.bb:1:error:oelint.var.mandatoryvar.HOMEPAGE:Variable 'HOMEPAGE' should be set [branch:true]
+/foo.bb:1:info:oelint.var.suggestedvar.CVE_PRODUCT:Variable 'CVE_PRODUCT' should be set [branch:true]
+/foo.bb:2:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"' [branch:true]
 ]], bufnr)
 
   assert.are.same(3, #result)
@@ -13,7 +13,7 @@ describe('linter.oelint-adv', function()
   local expected_error = {
     code = 'oelint.var.mandatoryvar.HOMEPAGE',
     source = 'oelint-adv',
-    message = 'Variable \'HOMEPAGE\' should be set',
+    message = 'Variable \'HOMEPAGE\' should be set [branch:true]',
     lnum = 0,
     col = 0,
     end_lnum = 0,
@@ -26,7 +26,7 @@ describe('linter.oelint-adv', function()
   local expected_info = {
     code = 'oelint.var.suggestedvar.CVE_PRODUCT',
     source = 'oelint-adv',
-    message = 'Variable \'CVE_PRODUCT\' should be set',
+    message = 'Variable \'CVE_PRODUCT\' should be set [branch:true]',
     lnum = 0,
     col = 0,
     end_lnum = 0,
@@ -39,7 +39,7 @@ describe('linter.oelint-adv', function()
   local expected_warning = {
     code = 'oelint.vars.spacesassignment',
     source = 'oelint-adv',
-    message = 'Suggest spaces around variable assignment. E.g. \'FOO = "BAR"\'',
+    message = 'Suggest spaces around variable assignment. E.g. \'FOO = "BAR"\' [branch:true]',
     lnum = 1,
     col = 0,
     end_lnum = 1,


### PR DESCRIPTION
Starting from commit:
```
commit a620ab1cefdeeef35f2e17150534b31d9a362529
Author: Konrad Weihmann <kweihmann@outlook.com>
Date:   Tue Aug 27 12:18:24 2024 +0000
```
`oelint-adv` adds `[branch:XXX]` to the end of the output line regardless of the provided `--messageformat`. So the output needs to be parsed correspondingly as it contains extra ':' symbol now.