### PR TITLE
credo: use stdin to communicate with the linter

### DIFF
--- a/lua/lint/linters/credo.lua
+++ b/lua/lint/linters/credo.lua
@@ -1,5 +1,5 @@
-local pattern = "%[%a%]%s+(.+)%s+([^:]+):(%d+):?(%d*)%s+(.*)"
-local groups = { "severity", "file", "lnum", "col", "message" }
+local pattern = "%[%a%]%s+(.+)%s+[^:]+:(%d+):?(%d*)%s+(.*)"
+local groups = { "severity", "lnum", "col", "message" }
 local severity = {
   ["↑"] = vim.diagnostic.severity.ERROR,
   ["↗"] = vim.diagnostic.severity.WARN,
@@ -10,8 +10,8 @@ local severity = {
 
 return {
   cmd = "mix",
-  stdin = false,
-  args = { "credo", "list", "--format=oneline", "--strict" },
+  stdin = true,
+  args = { "credo", "--read-from-stdin", "list", "--format=oneline", "--strict" },
   stream = "stdout",
   ignore_exitcode = true, -- credo only returns 0 if there are no errors
   parser = require("lint.parser").from_pattern(pattern, groups, severity, { ["source"] = "credo" }),


### PR DESCRIPTION
we don't parse the filename anymore since it's now always 'stdin'.