### PR TITLE
fix: fortitude doesn't read from stdin

### DIFF
--- a/lua/lint/linters/fortitude.lua
+++ b/lua/lint/linters/fortitude.lua
@@ -10,7 +10,7 @@ local severity_map = {
 
 return {
   cmd = "fortitude",
-  stdin = true,
+  stdin = false,
   append_fname = true,
   args = { "check", "--output-format", "json" },
   stream = nil,


### PR DESCRIPTION
Fortitude doesn't read from stdin and just give suggestions for every file in the same directory. This now has the side effect that suggestions get displayed in the wrong files. This PR fixes this simple overside.