### PR TITLE
Add support to `zsh` linter for linting without writing file

### DIFF
--- a/lua/lint/linters/zsh.lua
+++ b/lua/lint/linters/zsh.lua
@@ -1,10 +1,21 @@
+local stdin = not vim.loop.os_uname().version:match("Windows")
+
+local args = {
+  "--no-exec",
+  "--no-rcs",
+  "--no-globalrcs",
+}
+if stdin then
+  table.insert(args, "/dev/stdin")
+end
+
 return {
   cmd = "zsh",
-  stdin = false,
+  stdin = stdin,
   ignore_exitcode = true,
-  args = { "--no-exec" },
+  args = args,
   stream = "stderr",
-  parser = require("lint.parser").from_errorformat("%f:%l:%m", {
+  parser = require("lint.parser").from_errorformat("%s:%l:%m", {
     source = "zsh",
     severity = vim.diagnostic.severity.ERROR,
   }),


### PR DESCRIPTION
If not on Windows, read from `stdin`, allowing linting to be performed immediately without writing the file.

Note: if `/dev/stdin` is not referenced, the line number is not produced:

```
$ printf "( foo" | zsh --no-exec /dev/stdin
/dev/stdin:1: parse error near `foo'

$ printf "( foo" | zsh --no-exec -
zsh: parse error near `foo'

$ printf "( foo" | zsh --no-exec
zsh: parse error near `foo'
```

which will not work on Windows