### PR TITLE
fix(gdlint): support file paths with whitespaces in parser pattern

### DIFF
--- a/lua/lint/linters/gdlint.lua
+++ b/lua/lint/linters/gdlint.lua
@@ -1,4 +1,4 @@
-local pattern = [[(%S+):(%d+):%s(%a+):%s(.*)]]
+local pattern = [[(.+):(%d+):%s(%a+):%s(.*)]]
 local groups = {
   'file',
   'lnum',


### PR DESCRIPTION
This PR updates the gdlint parser pattern to correctly handle file paths that contain whitespaces.

The previous pattern used %S+ to capture the file path, which only matched non-whitespace characters. This caused issues when the file path included whitespaces (e.g., Godot Projects/script.gd) resulting in incorrect or incomplete parsing of diagnostics. By switching to .+, we ensure that the entire file path (including whitespaces) is captured up to the first colon delimiter, allowing diagnostics to be correctly mapped to their source files.