### PR TITLE
feat(linters): add trivy_secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Other dedicated linters that are built-in are:
 | [tfsec][tfsec]                         | `tfsec`                |
 | [tlint][tlint]                         | `tlint`                |
 | [trivy][trivy]                         | `trivy`                |
+| [trivy_secret][trivy_secret]           | `trivy_secret`         |
 | [ts-standard][ts-standard]             | `ts-standard`          |
 | [twig-cs-fixer][twig-cs-fixer]         | `twig-cs-fixer`        |
 | [typos][typos]                         | `typos`                |
@@ -548,6 +549,7 @@ busted tests/
 [tfsec]: https://github.com/aquasecurity/tfsec
 [tlint]: https://github.com/tighten/tlint
 [trivy]: https://github.com/aquasecurity/trivy
+[trivy_secret]: https://github.com/aquasecurity/trivy
 [djlint]: https://djlint.com/
 [buildifier]: https://github.com/bazelbuild/buildtools/tree/master/buildifier
 [solhint]: https://protofire.github.io/solhint/

--- a/lua/lint/linters/trivy_secret.lua
+++ b/lua/lint/linters/trivy_secret.lua
@@ -1,0 +1,45 @@
+local severity_map = {
+  ["LOW"] = vim.diagnostic.severity.INFO,
+  ["MEDIUM"] = vim.diagnostic.severity.WARN,
+  ["HIGH"] = vim.diagnostic.severity.ERROR,
+  ["CRITICAL"] = vim.diagnostic.severity.ERROR,
+}
+
+return {
+  cmd = "trivy",
+  stdin = false,
+  append_fname = true,
+  args = { "--scanners", "secret", "--format", "json", "fs" },
+  stream = "stdout",
+  ignore_exitcode = false,
+  parser = function(output, bufnr)
+    local diagnostics = {}
+
+    local decoded = vim.json.decode(output)
+    local fpath = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t")
+
+    for _, result in ipairs(decoded and decoded.Results or {}) do
+      -- trivy can return Results for other files; only report for current buffer
+      --
+      if result.Target == fpath then
+        for _, secret in ipairs(result.Secrets or {}) do
+          local title = secret.Title or "<No Title>"
+          local id = secret.RuleID or "<No RuleID>"
+          local lnum = secret.StartLine and secret.StartLine - 1 or 0
+          local end_lnum = secret.EndLine and secret.EndLine - 1 or 0
+          table.insert(diagnostics, {
+            source = "trivy_secret",
+            message = string.format("%s", title),
+            col = 0,
+            end_col = 0,
+            lnum = lnum,
+            end_lnum = end_lnum,
+            code = id,
+            severity = severity_map[secret.Severity] or vim.diagnostic.severity.WARN,
+          })
+        end
+      end
+    end
+    return diagnostics
+  end,
+}

--- a/spec/trivy_secret_spec.lua
+++ b/spec/trivy_secret_spec.lua
@@ -1,0 +1,101 @@
+describe("linter.trivy_secret", function()
+  it("Parses output sample", function()
+    local parser = require("lint.linters.trivy_secret").parser
+    local bufnr = vim.uri_to_bufnr("file:///ingress.yaml")
+    local output = [[
+{
+  "SchemaVersion": 2,
+  "CreatedAt": "2025-05-14T00:38:06.703758502+03:00",
+  "ArtifactName": "ingress.yaml",
+  "ArtifactType": "filesystem",
+  "Metadata": {
+    "ImageConfig": {
+      "architecture": "",
+      "created": "0001-01-01T00:00:00Z",
+      "os": "",
+      "rootfs": {
+        "type": "",
+        "diff_ids": null
+      },
+      "config": {}
+    }
+  },
+  "Results": [
+    {
+      "Target": "ingress.yaml",
+      "Class": "secret",
+      "Secrets": [
+        {
+          "RuleID": "private-key",
+          "Category": "AsymmetricPrivateKey",
+          "Severity": "HIGH",
+          "Title": "Asymmetric Private Key",
+          "StartLine": 3,
+          "EndLine": 3,
+          "Code": {
+            "Lines": [
+              {
+                "Number": 1,
+                "Content": "---",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "---",
+                "FirstCause": false,
+                "LastCause": false
+              },
+              {
+                "Number": 2,
+                "Content": "key: |",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "key: |",
+                "FirstCause": false,
+                "LastCause": false
+              },
+              {
+                "Number": 3,
+                "Content": "  -----BEGIN PRIVATE KEY-----**************-----END PRIVATE KEY-----",
+                "IsCause": true,
+                "Annotation": "",
+                "Truncated": false,
+                "Highlighted": "  -----BEGIN PRIVATE KEY-----**************-----END PRIVATE KEY-----",
+                "FirstCause": true,
+                "LastCause": true
+              },
+              {
+                "Number": 4,
+                "Content": "",
+                "IsCause": false,
+                "Annotation": "",
+                "Truncated": false,
+                "FirstCause": false,
+                "LastCause": false
+              }
+            ]
+          },
+          "Match": "  -----BEGIN PRIVATE KEY-----**************-----END PRIVATE KEY-----",
+          "Layer": {}
+        }
+      ]
+    }
+  ]
+}
+    ]]
+    local result = parser(output, bufnr)
+    local expected = {
+      {
+        source = "trivy_secret",
+        message = "Asymmetric Private Key",
+        lnum = 2,
+        end_lnum = 2,
+        col = 0,
+        end_col = 0,
+        severity = vim.diagnostic.severity.ERROR,
+        code = "private-key",
+      },
+    }
+    assert.are.same(expected, result)
+  end)
+end)


### PR DESCRIPTION
nvim-lint already have trivy linter, but it only scans for [misconfig](https://github.com/mfussenegger/nvim-lint/blob/fdb04e9285edefbe25a02a31a35e8fbb10fe054d/lua/lint/linters/trivy.lua#L12), this PR adding secret scanner functionality to make more safer development process

POC:
![изображение](https://github.com/user-attachments/assets/44a0bb5f-cfcc-4e0d-88e0-09fc08431b8d)
