### PR TITLE
Use json1 format for shellcheck

### DIFF
--- a/lua/lint/linters/shellcheck.lua
+++ b/lua/lint/linters/shellcheck.lua
@@ -9,7 +9,7 @@ return {
   cmd = 'shellcheck',
   stdin = true,
   args = {
-    '--format', 'json',
+    '--format', 'json1',
     '-',
   },
   ignore_exitcode = true,
@@ -17,7 +17,7 @@ return {
     if output == "" then return {} end
     local decoded = vim.json.decode(output)
     local diagnostics = {}
-    for _, item in ipairs(decoded or {}) do
+    for _, item in ipairs(decoded.comments or {}) do
       table.insert(diagnostics, {
         lnum = item.line - 1,
         col = item.column - 1,


### PR DESCRIPTION
If you check the [shellcheck docs](https://github.com/koalaman/shellcheck/blob/20d11c1c33df71a375406c981a629269ee5149a2/shellcheck.1.md?plain=1#L188), you find that `json` is "a legacy version of the **json1** format. It's a raw array of comments, and all offsets have a tab stop of 8."

This modifies the shellcheck linter to use the `json1` format, which has existed for [at least 4 years](https://github.com/koalaman/shellcheck/commit/5ccaddbcc2455c7b5c753014b16dcb9f8ec78bdb).

This fixes column offsets when your shell script uses hard tabs and the `tabstop` setting is anything other than 8.