### PR TITLE
fix(cfn-lint): use stdin

### DIFF
--- a/lua/lint/linters/cfn_lint.lua
+++ b/lua/lint/linters/cfn_lint.lua
@@ -1,5 +1,5 @@
-local pattern = "([^:]+):(%d+):(%d+):(%d+):(%d+):(%w)(%d+):(.*)"
-local groups = { "file", "lnum", "col", "end_lnum", "end_col", "severity", "code", "message" }
+local pattern = "[^:]+:(%d+):(%d+):(%d+):(%d+):(%w)(%d+):(.*)"
+local groups = { "lnum", "col", "end_lnum", "end_col", "severity", "code", "message" }
 local severity_map = {
   ["W"] = vim.diagnostic.severity.WARN,
   ["E"] = vim.diagnostic.severity.ERROR,
@@ -8,7 +8,7 @@ local severity_map = {
 return {
   cmd = "cfn-lint",
   args = { "--format", "parseable" },
-  stdin = false,
+  stdin = true,
   ignore_exitcode = true,
   parser = require("lint.parser").from_pattern(pattern, groups, severity_map, { ["source"] = "cfn-lint" }),
 }


### PR DESCRIPTION
cfn-lint does support stdin

`echo 'Resources: {}' | cfn-lint`