### PR TITLE
shellcheck: use file on disk when possible

### DIFF
--- a/lua/lint/linters/shellcheck.lua
+++ b/lua/lint/linters/shellcheck.lua
@@ -5,12 +5,29 @@ local severities = {
   style = vim.diagnostic.severity.HINT,
 }
 
+-- In order to resolve the special path `SCRIPTDIR` in shellcheck's
+-- `source-path` directive it is necessary to pass the source as a filename
+-- rather than to stdin. To still be able to lint unnamed buffers we specify
+-- `stdin = true` and `-` as the filename as fallback. This works because
+-- shellcheck ignores stdin input when there are filenames in the argument
+-- list. This workaround could be removed when/if shellcheck implements
+-- --stdin-filename, see https://github.com/koalaman/shellcheck/issues/2735.
+local function filename_or_stdin()
+  local bufname = vim.api.nvim_buf_get_name(0)
+  local file = vim.fn.fnameescape(vim.fn.fnamemodify(bufname, ':p'))
+  if vim.bo.buftype == '' and vim.fn.filereadable(file) == 1 then
+    return file
+  end
+  return '-'
+end
+
+
 return {
   cmd = 'shellcheck',
   stdin = true,
   args = {
     '--format', 'json1',
-    '-',
+    filename_or_stdin,
   },
   ignore_exitcode = true,
   parser = function(output)


### PR DESCRIPTION
The motivation for this is to enable [shellcheck's `source-path` directive to resolve the special path `SCRIPTDIR` correctly](https://github.com/koalaman/shellcheck/blob/20d11c1c33df71a375406c981a629269ee5149a2/shellcheck.1.md?plain=1#L278-L284), which only works when passing the input as a filename in the argument list. To still be able to lint unnamed buffers we specify `stdin = true` and `-` as the filename as fallback. This works because shellcheck ignores stdin input when there are filenames in the argument list. This workaround could be removed when/if [shellcheck implements `--stdin-filename`](https://github.com/koalaman/shellcheck/issues/2735).