### PR TITLE
Update PHP_CodeSniffer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ busted tests/
 [ksh]: https://github.com/ksh93/ksh
 [ktlint]: https://github.com/pinterest/ktlint
 [php]: https://www.php.net/
-[phpcs]: https://github.com/squizlabs/PHP_CodeSniffer
+[phpcs]: https://github.com/PHPCSStandards/PHP_CodeSniffer
 [phpinsights]: https://github.com/nunomaduro/phpinsights
 [phpmd]: https://phpmd.org/
 [phpstan]: https://phpstan.org/


### PR DESCRIPTION
Updates README to point to the correct successor.


> This repository has been abandoned. Its successor is [PHPCSStandards/PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer/)
> — [squizlabs/PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/README.md?plain=1#L2)
