### PR TITLE
Fix rust subdirectories,minor improvements

### DIFF
--- a/lua/lint/linters/clippy.lua
+++ b/lua/lint/linters/clippy.lua
@@ -19,6 +19,11 @@ local function parse(diagnostics, file_name, item)
         message = message .. "\nSuggested replacement:\n\n" .. tostring(span.suggested_replacement)
       end
 
+      local rendered = item.message
+      if item.rendered ~= vim.NIL then
+        rendered = item.rendered
+      end
+
       table.insert(diagnostics, {
         lnum = span.line_start - 1,
         end_lnum = span.line_end - 1,
@@ -28,7 +33,7 @@ local function parse(diagnostics, file_name, item)
         source = "clippy",
         message = message,
         user_data = {
-          rendered = item.rendered or item.message,
+          rendered = rendered,
         },
       })
     end


### PR DESCRIPTION
### Overview 
A few improvements/fixes that would be great to be included in the Rust linter, clippy.
- Allow the linter to run when the project has many directories and nvim was opened in a directory other than the main one. Currently, the linter does not run if nvim isn't opened in the main directory.
- Ignore the linter exit code, as it displays a warning when there is a compilation error in the project.
- Add the rendered message in user_data


### Testing Instructions
For the issue where the linter is not running:
- Create a Rust project where there is at least a subdirectory in the directory that Cargo.toml exists.
- Open nvim in the subdirectory.
- Try to run clippy linter.
- Observe that the linter doesn't run.
- This happens because the linter returns filenames relatively to the project root while the file_name in parse is relative to the cwd.
- Checkout this branch and observe that the linter is run normally.

To test the user data change:
- Add a diagnostic.float configuration that uses the rendered data e.g.:
```
    vim.diagnostic.config {
      float = {
        border = 'rounded',
        source = 'if_many',
        format = function(diagnostic)
          return diagnostic.user_data.rendered
        end,
      },
```
- Observe that diagnostic float window contain more information


