### PR TITLE
Add first line in doc for local additions

### DIFF
--- a/doc/lint.txt
+++ b/doc/lint.txt
@@ -1,3 +1,4 @@
+*lint.txt*                                         An asynchronous linter plugin
 ==============================================================================
 Table of Contents                                                     *lint.toc*
 


### PR DESCRIPTION
The documentation for vim help pages states that a first line is required for the file to appear under `:help local-additions`, with the following format: `*tag* description`

This change adds such line