### PR TITLE
fix(oxlint): add end_col and end_line

### DIFF
--- a/lua/lint/linters/oxlint.lua
+++ b/lua/lint/linters/oxlint.lua
@@ -1,15 +1,15 @@
-local pattern = "(.*):(%d*):(%d*): (.*) %[([EW][arnogi]*)%/([a-z%/%-%(%)]*)%]"
+local pattern = "::([^ ]+) file=(.*),line=(%d+),endLine=(%d+),col=(%d+),endColumn=(%d+),title=(.*)::(.*)"
 local severities = {
-  ["Error"] = vim.diagnostic.severity.ERROR,
-  ["Warning"] = vim.diagnostic.severity.WARN,
+  ["error"] = vim.diagnostic.severity.ERROR,
+  ["warning"] = vim.diagnostic.severity.WARN,
 }
-local groups = { "file", "lnum", "col", "message", "severity", "code" }
+local groups = { "severity", "file", "lnum", "end_lnum", "col", "end_col", "code", "message" }
 local defaults = { ["source"] = "oxlint" }
 
 return {
   cmd = "oxlint",
   stdin = false,
-  args = { "--format", "unix" },
+  args = { "--format", "github" },
   stream = "stdout",
   ignore_exitcode = true,
   parser = require("lint.parser").from_pattern(pattern, groups, severities, defaults, {})


### PR DESCRIPTION
Oxlint can give the end column and end line, but we need to use the github format.
