### PR TITLE
fix(ansible-lint): update efm to match all output formats

### DIFF
--- a/lua/lint/linters/ansible_lint.lua
+++ b/lua/lint/linters/ansible_lint.lua
@@ -1,8 +1,9 @@
+local efm = '%f:%l:%c: %m,%f:%l: %m'
 return {
   cmd = 'ansible-lint',
   args = { '-p', '--nocolor' },
   ignore_exitcode = true,
-  parser = require('lint.parser').from_errorformat('%f:%l: %m', {
+  parser = require('lint.parser').from_errorformat(efm, {
     source = 'ansible-lint',
     severity = vim.diagnostic.severity.INFO
   })


### PR DESCRIPTION
This PR updates the `ansible-lint` errorformat to match the optional row in the parseable output:

```
$ ansible-lint -p example.yml
WARNING  Listing 2 violation(s) that are fatal
example.yml:18: no-free-form: Avoid using free-form when calling module actions. (service)
example.yml:19:7: fqcn[action-core]: Use FQCN for builtin module actions (service).
```

To match both formats the efm is updated to `%f:%l:%c: %m,%f:%l: %m`.