### PR TITLE
stylelint: warnings unreported if no errors present

### DIFF
--- a/lua/lint/linters/stylelint.lua
+++ b/lua/lint/linters/stylelint.lua
@@ -43,24 +43,22 @@ return {
       }
     end
     local diagnostics = {}
-    if decoded.errored then
-      for _, message in ipairs(decoded.warnings) do
-        table.insert(diagnostics, {
-          lnum = message.line - 1,
-          col = message.column - 1,
-          end_lnum = message.line - 1,
-          end_col = message.column - 1,
-          message = message.text,
-          code = message.rule,
-          user_data = {
-            lsp = {
-              code = message.rule,
-            }
+    for _, message in ipairs(decoded.warnings) do
+      table.insert(diagnostics, {
+        lnum = message.line - 1,
+        col = message.column - 1,
+        end_lnum = message.line - 1,
+        end_col = message.column - 1,
+        message = message.text,
+        code = message.rule,
+        user_data = {
+          lsp = {
+            code = message.rule,
           },
-          severity = severities[message.severity],
-          source = "stylelint",
-        })
-      end
+        },
+        severity = severities[message.severity],
+        source = "stylelint",
+      })
     end
     return diagnostics
   end


### PR DESCRIPTION
According to https://stylelint.io/user-guide/node-api#errored:

> errored
> Boolean. If true, at least one rule with an "error"-level severity registered a problem.

This means that if stylelint outputs only warnings, `errored` will be set to `false`. Here's a real example:

```
[
  {
    "source": "insight-regression-indicator.less",
    "deprecations": [],
    "invalidOptionWarnings": [],
    "parseErrors": [],
    "errored": false,
    "warnings": [
      {
        "line": 3,
        "column": 1,
        "endLine": 3,
        "endColumn": 2,
        "rule": "selector-disallowed-list",
        "severity": "warning",
        "text": "Unexpected selector \"*\""
      }
    ]
  }
]
```

However, creation of diagnostics from `stylelint`'s output is guarded by a `if decoded.errored` which means that in situations like above where only warnings are emitted, these warnings are not shown. 

With this PR these warnings are now shown:

<img width="1328" height="134" alt="image" src="https://github.com/user-attachments/assets/1fc12ca7-0e42-49a9-859c-55298312b163" />