### PR TITLE
oxlint: use local binary from node_modules if available

### DIFF
--- a/lua/lint/linters/oxlint.lua
+++ b/lua/lint/linters/oxlint.lua
@@ -5,12 +5,16 @@ local severities = {
 }
 local groups = { "severity", "file", "lnum", "end_lnum", "col", "end_col", "code", "message" }
 local defaults = { ["source"] = "oxlint" }
+local binary_name = "oxlint"
 
 return {
-  cmd = "oxlint",
+  cmd = function()
+    local local_binary = vim.fn.fnamemodify("./node_modules/.bin/" .. binary_name, ":p")
+    return vim.loop.fs_stat(local_binary) and local_binary or binary_name
+  end,
   stdin = false,
   args = { "--format", "github" },
   stream = "stdout",
   ignore_exitcode = true,
-  parser = require("lint.parser").from_pattern(pattern, groups, severities, defaults, {})
+  parser = require("lint.parser").from_pattern(pattern, groups, severities, defaults, {}),
 }


### PR DESCRIPTION
Similarly to many other linters, if oxlint is available in the current project under node_modules/.bin, use that binary instead of a globally installed one.