### PR TITLE
typos: handle spaces in paths

### DIFF
--- a/lua/lint/linters/typos.lua
+++ b/lua/lint/linters/typos.lua
@@ -25,7 +25,7 @@ return {
     --   {"type":"binary_file","path":"./lua/init_rs.so"}
     --   {"type":"typo","path":"./lua/plugins/23_package-info-nvim.lua","line_num":15,"byte_offset":37,"typo":"nd","corrections":["and"]}
     --   {"type":"binary_file","path":"./spell/en.utf-8.add.spl"}
-    for json in string.gmatch(output, "[%S]+") do
+    for json in string.gmatch(output, "[^\n]+") do
       local item = vim.json.decode(json)
 
       if item ~= nil and item.line_num ~= nil then


### PR DESCRIPTION
If you have a path with a space in it, it currently causes an error in
the typos parser because we match only on non-whitespace characters, not
on whole lines.

```
Diagnostics:
1. Parser failed. Error message:
   ...cal/share/nvim/lazy/nvim-lint/lua/lint/linters/typos.lua:29: Expected value but found unexpected end of string at character 49

   Output from linter:
   {"type":"typo","path":"/Users/gib/Library/Mobile Documents/foo.md","line_num":13,"byte_offset":479,"typo":"consitently","corrections":["consistently"]}
```

The typos CLI docs
(https://github.com/crate-ci/typos/tree/master?tab=readme-ov-file#custom)
say that it outputs "jsonlines", which I assume means that splitting on
newline is correct.