### PR TITLE
Fix: setloclist float error by using -1 instead of math.huge for end_col

### DIFF
--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -198,7 +198,7 @@ function M.for_sarif(skeleton)
             -- If endColumn is absent, it SHALL default to a value one greater
             -- than the column number of the last character on the line,
             -- excluding any newline sequence.
-            local end_col = region.endColumn and region.endColumn - 2 or math.huge
+            local end_col = region.endColumn and region.endColumn - 2 or -1
             table.insert(
               diagnostics,
               vim.tbl_extend("keep", {


### PR DESCRIPTION
### Description

When running ```vim.diagnostic.setloclist()``` the following error occurs:
```
E5108: Error executing lua: Vim:E805: Using a Float as a Number
stack traceback:
    [C]: in function 'setloclist'
    .../share/nvim/runtime/lua/vim/diagnostic.lua:913 in function 'set list'
    .../share/nvim/runtime/lua/vim/diagnostic.lua:2446: in function <.../share/nvim/runtime/lua/vim/diagnositc.lua:2445>
```

Installed nvim-lint with lazy.nvim and checkstyle through Mason, then configured ```linters_by_ft``` to use checkstyle with Java.

### Solution

The SARIF parser returns ```math.huge``` if ```region.endColumn``` doesn't exist, which is a float and therefore not accepted by ```setloclist```. Using -1 instead of ```math.huge``` fixes the error.

