### PR TITLE
vacuum: Do not filter by filename

### DIFF
--- a/lua/lint/linters/vacuum.lua
+++ b/lua/lint/linters/vacuum.lua
@@ -12,18 +12,8 @@ return {
   cmd = 'vacuum',
   args = { 'report', '--no-pretty', '--no-style', '--stdin', '--stdout' },
   stdin = true,
-  parser = function(output, bufnr, _)
+  parser = function(output)
     if vim.trim(output) == '' then
-      return {}
-    end
-
-    local allowed_filenames = {
-      ['openapi.json'] = true,
-      ['openapi.yaml'] = true,
-    }
-
-    local filename = vim.fs.basename(vim.api.nvim_buf_get_name(bufnr))
-    if not allowed_filenames[filename] then
       return {}
     end
 


### PR DESCRIPTION
This was a mistake, this shouldn't be the responsibility of the linter but of the user. Also, `vacuum` already detects when a file isn't an OpenAPI spec and it returns an empty report.

Closes #880