### PR TITLE
Fix detect secrets

### DIFF
--- a/lua/lint/linters/detect-secrets.lua
+++ b/lua/lint/linters/detect-secrets.lua
@@ -1,4 +1,5 @@
-local name = "linter-secrets"
+local name = "detect-secrets"
+
 return function()
   local args = { "scan" }
 


### PR DESCRIPTION
Fix 3 bugs related to detect-secrets linter:

- Executable and name. The correct detect-secrets executable is `detect-secrets` (instead of `linter-secrets`). See the official documentation at https://github.com/Yelp/detect-secrets

- Diagnostic column. Must be provided, otherwise Neovim throws an error. Because detect-secrets does not provide a column, I used a dummy column of 0

- Type annotation for diagnostic (must be `vim.Diagnostic` instead of `vim.Diagnostic.Set`)