### PR TITLE
Allow for a function to be passed in ``linter.args`` instead of just a list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ require('lint').linters.your_linter_name = {
   cmd = 'linter_cmd',
   stdin = true, -- or false if it doesn't support content input via stdin. In that case the filename is automatically added to the arguments.
   append_fname = true, -- Automatically append the file name to `args` if `stdin = false` (default: true)
-  args = {}, -- list of arguments. Can contain functions with zero arguments that will be evaluated once the linter is used.
+  args = {}, -- list of arguments. Can contain functions with zero arguments that will be evaluated once the linter is used. May also be a function returning this list.
   stream = nil, -- ('stdout' | 'stderr' | 'both') configure the stream to which the linter outputs the linting result.
   ignore_exitcode = false, -- set this to true if the linter exits with a code != 0 and that's considered normal.
   env = nil, -- custom environment table to use with the external process. Note that this replaces the *entire* environment, it is not additive.

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -175,11 +175,13 @@ M.linters = setmetatable({}, {
 })
 
 
+---@alias lint.Args (string|fun():string)[]
+
 ---A Linter
 ---@class lint.Linter
 ---@field name string
 ---@field cmd string command/executable
----@field args? (string|fun():string)[] command arguments
+---@field args? lint.Args|(fun():lint.Args) command arguments
 ---@field stdin? boolean send content via stdin. Defaults to false
 ---Automatically add the current file name to the commands arguments.
 ---Only has an effect if stdin is false
@@ -383,7 +385,14 @@ function M.lint(linter, opts)
     })
   end
   if linter.args then
-    vim.list_extend(args, vim.tbl_map(eval, linter.args))
+    local linter_args
+    if type(linter.args) == 'function' then
+      linter_args = linter.args()
+    else
+      ---@type lint.Args; It should not be a function at this point.
+      linter_args = linter.args
+    end
+    vim.list_extend(args, vim.tbl_map(eval, linter_args))
   end
   if not linter.stdin and linter.append_fname ~= false then
     table.insert(args, api.nvim_buf_get_name(bufnr))

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -379,7 +379,7 @@ function M.lint(linter, opts)
   if iswin then
     linter = vim.tbl_extend("force", linter, {
       cmd = "cmd.exe",
-      args = { "/C", linter.cmd, unpack(linter.args or {}) },
+      args = { "/C", linter.cmd },
     })
   end
   if linter.args then


### PR DESCRIPTION
See patch commits & their messages for more information.
The first patch contains a fix for Windows systems, regarding duplicating the ``linter.args`` value. The second contains the actual change. Finally, the last updates the README to provide some (minor) documentation for this feature.