### PR TITLE
feat: Add checkbashisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Other dedicated linters that are built-in are:
 | [buildifier][buildifier]               | `buildifier`           |
 | [cfn-lint][cfn-lint]                   | `cfn_lint`             |
 | [cfn_nag][cfn_nag]                     | `cfn_nag`              |
+| [checkbashisms][checkbashisms]         | `checkbashisms`
 | [checkmake][checkmake]                 | `checkmake`            |
 | [checkpatch.pl][checkpatch]            | `checkpatch`           |
 | [checkstyle][checkstyle]               | `checkstyle`           |
@@ -618,6 +619,7 @@ vimcats -t -f lua/lint.lua lua/lint/parser.lua > doc/lint.txt
 [nagelfar]: https://nagelfar.sourceforge.net/
 [oelint-adv]: https://github.com/priv-kweihmann/oelint-adv
 [cfn_nag]: https://github.com/stelligent/cfn_nag
+[checkbashisms]: https://tracker.debian.org/pkg/devscripts
 [checkmake]: https://github.com/mrtazz/checkmake
 [ruff]: https://github.com/astral-sh/ruff
 [janet]: https://github.com/janet-lang/janet

--- a/lua/lint/linters/checkbashisms.lua
+++ b/lua/lint/linters/checkbashisms.lua
@@ -1,16 +1,18 @@
 return {
   cmd = "checkbashisms",
-  stdin = false, -- Does not take stdin unless we give "-" as an arg
+  stdin = true, -- Only works if we give "-" as an arg
   append_fname = true,
   stream = "stdout",
   ignore_exitcode = true, -- exits > 0 if emits lints
   args = {
     "--lint",
+    "-",
   },
   -- checkbashism's manpage gives the following as the lint style output:
   -- {filename}:{lineno}:1: warning: possible bashism; {explanation}
   -- i.e. the column number and severity is entirely static
-  parser = require("lint.parser").from_errorformat("%f:%l:1: warning: possible bashism; %m", {
+  -- with stdin the file name is static as well
+  parser = require("lint.parser").from_errorformat("(stdin):%l:1: warning: possible bashism; %m", {
     source = "checkbashisms",
     severity = vim.diagnostic.severity.WARN,
   }),

--- a/lua/lint/linters/checkbashisms.lua
+++ b/lua/lint/linters/checkbashisms.lua
@@ -1,0 +1,17 @@
+return {
+  cmd = "checkbashisms",
+  stdin = false, -- Does not take stdin unless we give "-" as an arg
+  append_fname = true,
+  stream = "stdout",
+  ignore_exitcode = true, -- exits > 0 if emits lints
+  args = {
+    "--lint",
+  },
+  -- checkbashism's manpage gives the following as the lint style output:
+  -- {filename}:{lineno}:1: warning: possible bashism; {explanation}
+  -- i.e. the column number and severity is entirely static
+  parser = require("lint.parser").from_errorformat("%f:%l:1: warning: possible bashism; %m", {
+    source = "checkbashisms",
+    severity = vim.diagnostic.severity.WARN,
+  }),
+}


### PR DESCRIPTION
`checkbashisms` doesn't have the sort of project page people might expect, but there are at least some manpages available online, e.g. [checkbashisms(1) at die.net](https://linux.die.net/man/1/checkbashisms).

I gave [the Debian devscripts page](https://tracker.debian.org/pkg/devscripts) as the upstream because that's what it is, even though it's probably rather opaque for someone discovering it through the list of linters.