### PR TITLE
feat!(checkpatch): implement stdin handling

### DIFF
--- a/lua/lint/linters/checkpatch.lua
+++ b/lua/lint/linters/checkpatch.lua
@@ -1,48 +1,94 @@
 -- This favors the version of `checkpatch.pl` supplied by the project
 -- to which the file being linted belongs, falling back to a version
--- accessible via `$PATH`. If a user wishes to use a different version
--- of the script they can override "cmd" in their config:
--- require("lint").linters.checkpatch.cmd = '…/checkpatch.pl'
+-- accessible via `$PATH`.
 
-local tool_name = 'checkpatch.pl'
+local uv = vim.loop or vim.uv
 
--- path/to/file:line: severity: message
-local pattern = '([^:]+):(%d+): (%a+): (.+)'
-local groups = { 'file', 'lnum', 'severity', 'message' }
 local severity_map = {
   ['ERROR'] = vim.diagnostic.severity.ERROR,
   ['WARNING'] = vim.diagnostic.severity.WARN,
   ['CHECK'] = vim.diagnostic.severity.INFO,
 }
 
-local function locate_checkpatch()
-  local tool_path = vim.fs.joinpath(vim.fn.getcwd(), 'scripts', tool_name)
-  if vim.fn.executable(tool_path) == 1 then
-    return tool_path
+local checkpatch_ignore = {
+  'COMMIT_MESSAGE',
+  'MISSING_SIGN_OFF',
+  'OBSOLETE',
+  'PATCH_PREFIX',
+  'SPDX_LICENSE_TAG',
+}
+
+local caps_cache = {}
+
+local function get_caps(full_cmd)
+  local stat = uv.fs_stat(full_cmd)
+  local mtime = stat and stat.mtime.sec or 0
+  local cache_key = full_cmd .. ":" .. mtime
+  if caps_cache[cache_key] then
+    return caps_cache[cache_key]
   end
 
-  if vim.fn.executable(tool_name) == 1 then
-    return tool_name
-  end
-
-  -- If checkpatch executable is not found return "true" which is a valid command
-  -- that will not produce any diagnostic but return success error code. This will
-  -- allow enabling checkpatch linter globally and only return diagnostic if
-  -- a project is actually using it.
-  return 'true'
+  local f = io.open(full_cmd, 'rb')
+  if not f then return { ignore = false } end
+  local content = f:read(32768)
+  f:close()
+  local caps = {
+    ignore = content and content:find('ignore=s', 1, true) ~= nil or false
+  }
+  caps_cache[cache_key] = caps
+  return caps
 end
 
-return {
-  cmd = locate_checkpatch,
-  stdin = false,
-  args = {
-    '--strict',
-    '--terse',
-    '--file',
-  },
-  ignore_exitcode = true,
-  parser = require('lint.parser').from_pattern(
-    pattern, groups, severity_map,
-    { ['source'] = 'checkpatch' }
-  ),
-}
+local parser = require('lint.parser').from_pattern(
+  '^%-:(%d+): (%a+): (.+)',
+  { 'lnum', 'severity', 'message' },
+  severity_map,
+  { ['source'] = 'checkpatch' },
+  { lnum_offset = -3, end_lnum_offset = -3 }
+)
+
+---@return lint.Linter
+return function()
+  local cwd = vim.fn.getcwd()
+  local cmd = vim.fs.joinpath(cwd, 'scripts', 'checkpatch.pl')
+  if vim.fn.executable(cmd) == 0 then
+    cmd = 'checkpatch.pl'
+  end
+
+  local full_cmd = vim.fn.exepath(cmd)
+  if full_cmd == "" then
+    return {
+      name = 'checkpatch',
+      cmd = 'true',
+      stdin = false,
+      parser = parser,
+    }
+  end
+
+  local caps = get_caps(full_cmd)
+
+  return {
+    name = 'checkpatch',
+    cmd = 'sh',
+    stdin = true,
+    ignore_exitcode = true,
+    args = {
+      '-c',
+      function()
+        local relpath = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ':p:.')
+        local args = { '--terse', '--strict', '--no-signoff' }
+        if caps.ignore then
+          table.insert(args, '--ignore')
+          table.insert(args, table.concat(checkpatch_ignore, ','))
+        end
+        return string.format(
+          'diff -u --label /dev/null --label %s /dev/null - | %s %s -',
+          vim.fn.shellescape(relpath),
+          vim.fn.shellescape(full_cmd),
+          table.concat(args, ' ')
+        )
+      end
+    },
+    parser = parser,
+  }
+end

--- a/spec/checkpatch_spec.lua
+++ b/spec/checkpatch_spec.lua
@@ -1,12 +1,17 @@
 describe('linter.checkpatch', function()
   it('can parse the output', function()
-    local parser = require('lint.linters.checkpatch').parser
+    local linter = require('lint.linters.checkpatch')
+    if type(linter) == 'function' then
+      linter = linter()
+    end
+    local parser = linter.parser
     local bufnr = vim.uri_to_bufnr('file:///foo.c')
-    local result = parser([[
-/foo.c:6: CHECK: Please don't use multiple blank lines
-/foo.c:8: WARNING: Missing a blank line after declarations
-/foo.c:10: ERROR: switch and case should be at the same indent
-]], bufnr)
+    local test_output = [[
+-:9: CHECK: Please don't use multiple blank lines
+-:11: WARNING: Missing a blank line after declarations
+-:13: ERROR: switch and case should be at the same indent
+]]
+    local result = parser(test_output, bufnr)
 
   assert.are.same(3, #result)
 


### PR DESCRIPTION
This change updates the checkpatch linter to support evaluating unsaved buffers so that it can run and provide updated results as soon as user exits insert mode.

Unfortunately kernel maintainer is against fixing checkpatch.pl's full file mode to properly handle stdin [1] so we have to work around this generating a diff against /dev/null and passing it to checkpatch instead.

The linter dynamically detects if the checkpatch script supports the '--ignore' flag and applies common ignores if available (some of them are too expensive for an online linter and are not changing often: "obsolete" and "SPDX check", while others do not make sense for our use case).

Unfortunately because now command is a "diff ... | checkpatch ..." it is hard to override it. The suggestion therefore is to make sure custom checkpatch (if needed) is first in $PATH.

Because linter code now returns function and not a table this change marked as breaking.

[1] https://lore.kernel.org/r/acTPXMJfkHLeItrK@google.com/