### PR TITLE
Fix golangci-lint reporting "undefined" errors in go.work environments

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -21,11 +21,23 @@ local getArgs = function()
   if not ok then
     return
   end
+
+  local go_work_location
+  ok, go_work_location = pcall(vim.fn.system, { 'go', 'env', 'GOWORK' })
+  if not ok then
+    return
+  end
+
   local filename_modifier = ':h'
   -- Remove extra whitespace like newline characters
   go_mod_location = go_mod_location:gsub('%s+', '')
-  -- No go.mod file was found, so just lint the buffer directly
-  if go_mod_location == '/dev/null' or go_mod_location == '' then
+  go_work_location = go_work_location:gsub('%s+', '')
+
+  -- No go.mod or go.work file was found, so just lint the buffer directly
+  local no_gomod = go_mod_location == '/dev/null' or go_mod_location == ''
+  local no_gowork = go_work_location == '/dev/null' or go_work_location == ''
+
+  if no_gomod and no_gowork then
     filename_modifier = ':p'
   end
 


### PR DESCRIPTION
When opening a session at the root of a Go workspace (go.work) where no go.mod exists, go env GOMOD returns /dev/null. This causes the script to fall back to single-file mode. As a result, golangci-lint only analyzes the current buffer, ignoring other files in the same package and triggering false positive "undefined" errors for cross-file variables.

Added a check for GOWORK. The script now verifies both GOMOD and GOWORK. It will only fall back to single-file mode if both are empty or /dev/null. This preserves the directory-level linting (:h) behavior required for Go workspaces to correctly resolve package-level variables.