### PR TITLE
Fix ameba parse error caused by missing "null" check

### DIFF
--- a/lua/lint/linters/ameba.lua
+++ b/lua/lint/linters/ameba.lua
@@ -28,8 +28,8 @@ return {
         code = issue.rule_name,
         lnum = issue.location.line - 1,
         col = issue.location.column - 1,
-        end_col = type(issue.end_location.column) == "number" and issue.location.column - 1 or nil,
-        end_lnum = type(issue.end_location.line) == "number" and issue.location.line - 1 or nil,
+        end_col = type(issue.end_location.column) == "number" and issue.end_location.column or nil,
+        end_lnum = type(issue.end_location.line) == "number" and issue.end_location.line - 1 or nil,
         message = issue.message,
         severity = severity_map[issue.severity],
       })

--- a/lua/lint/linters/ameba.lua
+++ b/lua/lint/linters/ameba.lua
@@ -28,8 +28,8 @@ return {
         code = issue.rule_name,
         lnum = issue.location.line - 1,
         col = issue.location.column - 1,
-        end_col = issue.end_location.column,
-        end_lnum = issue.end_location.line - 1,
+        end_col = type(issue.end_location.column) == "number" and issue.location.column - 1 or nil,
+        end_lnum = type(issue.end_location.line) == "number" and issue.location.line - 1 or nil,
         message = issue.message,
         severity = severity_map[issue.severity],
       })

--- a/spec/ameba_spec.lua
+++ b/spec/ameba_spec.lua
@@ -81,4 +81,45 @@ describe("linter.ameba", function()
     local result = parser([[{ "sources": [] }]])
     assert.are.same(0, #result)
   end)
+
+  it("can handle end_location having null values", function()
+    local parser = require("lint.linters.ameba").parser
+    local result = parser([[
+      {
+        "sources": [
+          {
+            "path": "src/test.cr",
+            "issues": [
+              {
+                "rule_name": "Documentation/DocumentationAdmonition",
+                "severity": "Warning",
+                "message": "Found a TODO admonition in the documentation",
+                "location": {
+                  "line": 5,
+                  "column": 1
+                },
+                "end_location": {
+                  "line": null,
+                  "column": null
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]])
+
+    local expected = {
+      source = "ameba",
+      lnum = 4,
+      col = 0,
+      end_lnum = nil,
+      end_col = nil,
+      severity = vim.diagnostic.severity.WARN,
+      message = "Found a TODO admonition in the documentation",
+      code = "Documentation/DocumentationAdmonition",
+    }
+
+    assert.are.same(expected, result[1])
+  end)
 end)


### PR DESCRIPTION
Ameba sometimes returns null values for the end_location. The original implementation wasn't checking for this possibility resulting in a ParserError. Below is a sample of ameba's output that was triggering the error:

```sh
$ bin/ameba src/main.cr --format json
{"sources":[{"path":"src/main.cr","issues":[{"rule_name":"Documentation/DocumentationAdmonition","severity":"Warning","message":"Found a TODO admonition in a comment","location":{"line":1,"column":1},"end_location":{"line":null,"column":null}},{"rule_name":"Documentation/DocumentationAdmonition","severity":"Warning","message":"Found a TODO admonition in a comment","location":{"line":5,"column":3},"end_location":{"line":null,"column":null}}]}],"metadata":{"ameba_version":"1.6.4","crystal_version":"1.20.1"},"summary":{"target_sources_count":1,"issues_count":2}}
```