### PR TITLE
clippy: file_name relative to lsp root dir (if available)

### DIFF
--- a/lua/lint/linters/clippy.lua
+++ b/lua/lint/linters/clippy.lua
@@ -38,7 +38,13 @@ return {
     local diagnostics = {}
     local items = #output > 0 and vim.split(output, "\n") or {}
     local file_name = vim.api.nvim_buf_get_name(bufnr)
-    file_name = vim.fn.fnamemodify(file_name, ":.")
+    local lsp_root = vim.lsp.get_clients({ bufnr = bufnr })[1].root_dir
+    if not lsp_root or string.len(lsp_root) == 0 then
+      file_name = vim.fn.fnamemodify(file_name, ":.")
+    else
+      file_name = vim.fn.fnamemodify(file_name, "p:")
+      file_name = vim.fn.fnamemodify(file_name, ":s?"..lsp_root.."/??")
+    end
 
     for _, i in ipairs(items) do
       local item = i ~= "" and vim.json.decode(i) or {}


### PR DESCRIPTION
I tried to use rust clippy linter, but it did not show any clippy errors. It seems clippy json output `span.file_name` is always relative to the directory where `Cargo.toml` is located, but nvim-lint tries to compare it to `file_name` variable that is relative to cwd.

I don't know if there already is some way to fix the paths, but this is my attempt - just use the `root_dir` lsp has figured out, if available.