### PR TITLE
oelint: Fix parsing of color enabled output

### DIFF
--- a/lua/lint/linters/oelint-adv.lua
+++ b/lua/lint/linters/oelint-adv.lua
@@ -7,6 +7,19 @@ local severity_map = {
   ['info'] = vim.diagnostic.severity.INFO,
 }
 
+local parser_core = require('lint.parser').from_pattern(
+  pattern, groups, severity_map,
+  { ['source'] = 'oelint-adv' }
+)
+
+local function strip_ansi_codes(s)
+  return s and s:gsub('\27%[[0-9;]*m', '') or s
+end
+
+local function parser(output, ...)
+  return parser_core(strip_ansi_codes(output), ...)
+end
+
 return {
   cmd = 'oelint-adv',
   stdin = false,
@@ -16,8 +29,5 @@ return {
   },
   ignore_exitcode = true,
   stream = 'stderr',
-  parser = require('lint.parser').from_pattern(
-    pattern, groups, severity_map,
-    { ['source'] = 'oelint-adv' }
-  ),
+  parser = parser,
 }

--- a/lua/lint/linters/oelint-adv.lua
+++ b/lua/lint/linters/oelint-adv.lua
@@ -14,6 +14,9 @@ return {
     '--quiet',
     '--messageformat={path}:{line}:{severity}:{id}:{msg}',
   },
+  env = {
+    ["NO_COLOR"] = "1",
+  },
   ignore_exitcode = true,
   stream = 'stderr',
   parser = require('lint.parser').from_pattern(

--- a/lua/lint/linters/oelint-adv.lua
+++ b/lua/lint/linters/oelint-adv.lua
@@ -7,19 +7,6 @@ local severity_map = {
   ['info'] = vim.diagnostic.severity.INFO,
 }
 
-local parser_core = require('lint.parser').from_pattern(
-  pattern, groups, severity_map,
-  { ['source'] = 'oelint-adv' }
-)
-
-local function strip_ansi_codes(s)
-  return s and s:gsub('\27%[[0-9;]*m', '') or s
-end
-
-local function parser(output, ...)
-  return parser_core(strip_ansi_codes(output), ...)
-end
-
 return {
   cmd = 'oelint-adv',
   stdin = false,
@@ -29,5 +16,8 @@ return {
   },
   ignore_exitcode = true,
   stream = 'stderr',
-  parser = parser,
+  parser = require('lint.parser').from_pattern(
+    pattern, groups, severity_map,
+    { ['source'] = 'oelint-adv' }
+  ),
 }

--- a/lua/lint/linters/oelint-adv.lua
+++ b/lua/lint/linters/oelint-adv.lua
@@ -16,6 +16,7 @@ return {
   },
   env = {
     ["NO_COLOR"] = "1",
+    ["HOME"] = os.getenv("HOME"),
   },
   ignore_exitcode = true,
   stream = 'stderr',

--- a/spec/oelint-adv_spec.lua
+++ b/spec/oelint-adv_spec.lua
@@ -2,14 +2,13 @@ describe('linter.oelint-adv', function()
   it('can parse the output', function()
     local parser = require('lint.linters.oelint-adv').parser
     local bufnr = vim.uri_to_bufnr('file:///foo.bb')
-    local escape_seq = string.char(27)
     local result = parser([[
 /foo.bb:1:error:oelint.var.mandatoryvar.HOMEPAGE:Variable 'HOMEPAGE' should be set [branch:true]
 /foo.bb:1:info:oelint.var.suggestedvar.CVE_PRODUCT:Variable 'CVE_PRODUCT' should be set [branch:true]
 /foo.bb:2:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"' [branch:true]
-]] .. escape_seq .. "[31m/foo.bb:17:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set" .. escape_seq .. "[0m [branch:true]", bufnr)
+]], bufnr)
 
-  assert.are.same(4, #result)
+  assert.are.same(3, #result)
 
   local expected_error = {
     code = 'oelint.var.mandatoryvar.HOMEPAGE',
@@ -49,19 +48,6 @@ describe('linter.oelint-adv', function()
     user_data = { lsp = { code = 'oelint.vars.spacesassignment' } },
   }
   assert.are.same(expected_warning, result[3])
-
-  local expected_withcolor = {
-    code = 'oelint.var.mandatoryvar.DESCRIPTION',
-    source = 'oelint-adv',
-    message = 'Variable \'DESCRIPTION\' should be set [branch:true]',
-    lnum = 16,
-    col = 0,
-    end_lnum = 16,
-    end_col = 0,
-    severity = vim.diagnostic.severity.ERROR,
-    user_data = { lsp = { code = 'oelint.var.mandatoryvar.DESCRIPTION' } },
-  }
-  assert.are.same(expected_withcolor, result[4])
 
   end)
 end)

--- a/spec/oelint-adv_spec.lua
+++ b/spec/oelint-adv_spec.lua
@@ -2,13 +2,14 @@ describe('linter.oelint-adv', function()
   it('can parse the output', function()
     local parser = require('lint.linters.oelint-adv').parser
     local bufnr = vim.uri_to_bufnr('file:///foo.bb')
+    local escape_seq = string.char(27)
     local result = parser([[
 /foo.bb:1:error:oelint.var.mandatoryvar.HOMEPAGE:Variable 'HOMEPAGE' should be set [branch:true]
 /foo.bb:1:info:oelint.var.suggestedvar.CVE_PRODUCT:Variable 'CVE_PRODUCT' should be set [branch:true]
 /foo.bb:2:warning:oelint.vars.spacesassignment:Suggest spaces around variable assignment. E.g. 'FOO = "BAR"' [branch:true]
-]], bufnr)
+]] .. escape_seq .. "[31m/foo.bb:17:error:oelint.var.mandatoryvar.DESCRIPTION:Variable 'DESCRIPTION' should be set" .. escape_seq .. "[0m [branch:true]", bufnr)
 
-  assert.are.same(3, #result)
+  assert.are.same(4, #result)
 
   local expected_error = {
     code = 'oelint.var.mandatoryvar.HOMEPAGE',
@@ -48,6 +49,19 @@ describe('linter.oelint-adv', function()
     user_data = { lsp = { code = 'oelint.vars.spacesassignment' } },
   }
   assert.are.same(expected_warning, result[3])
+
+  local expected_withcolor = {
+    code = 'oelint.var.mandatoryvar.DESCRIPTION',
+    source = 'oelint-adv',
+    message = 'Variable \'DESCRIPTION\' should be set [branch:true]',
+    lnum = 16,
+    col = 0,
+    end_lnum = 16,
+    end_col = 0,
+    severity = vim.diagnostic.severity.ERROR,
+    user_data = { lsp = { code = 'oelint.var.mandatoryvar.DESCRIPTION' } },
+  }
+  assert.are.same(expected_withcolor, result[4])
 
   end)
 end)


### PR DESCRIPTION
If color is enabled through oelint configuration the parser wont match and no issues are reported.

Stripping the ANSI color sequences from the linter output addresses this.