### PR TITLE
ci: Modernize deprecated actions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Lint Code Base
         uses: github/super-linter/slim@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         neovim_version: ['nightly', 'v0.9.5']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup neovim
         uses: rhysd/action-setup-vim@v1
@@ -24,7 +24,7 @@ jobs:
           version: ${{ matrix.neovim_version }}
 
       - name: Install Lua
-        uses: leso-kn/gh-actions-lua@master
+        uses: leafo/gh-actions-lua@v13
         with:
           luaVersion: "5.1"
 


### PR DESCRIPTION
Node.js 20 based actions are deprecated and will be removed soon.

This addresses following warnings:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, leso-kn/gh-actions-lua@master. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Switching from `leso-kn/gh-actions-lua` to it's base project `leafo/gh-actions-lua` is necessary as the former is outdated and doesn't provide a fix; the latter does.