### PR TITLE
credo: pass buffer filename to --read-from-stdin

### DIFF
--- a/lua/lint/linters/credo.lua
+++ b/lua/lint/linters/credo.lua
@@ -11,7 +11,16 @@ local severity = {
 return {
   cmd = "mix",
   stdin = true,
-  args = { "credo", "--read-from-stdin", "list", "--format=oneline", "--strict" },
+  args = {
+    "credo",
+    "list",
+    function()
+      return vim.api.nvim_buf_get_name(0)
+    end,
+    "--read-from-stdin",
+    "--strict",
+    "--format=oneline",
+  },
   stream = "stdout",
   ignore_exitcode = true, -- credo only returns 0 if there are no errors
   parser = require("lint.parser").from_pattern(pattern, groups, severity, { ["source"] = "credo" }),


### PR DESCRIPTION
Credo needs the filename to decide whether a file should be skipped, but the stdin source was unnamed. Pass the buffer path.