### PR TITLE
fix: suppress cd output when changing directories during linting

### DIFF
--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -340,7 +340,7 @@ local function with_cwd(cwd, fn, ...)
   if curcwd == cwd then
     return fn(...)
   else
-    local mods = { noautocmd = true }
+    local mods = { noautocmd = true, silent = true }
     vim.cmd.cd({cwd, mods = mods})
     local ok, result = pcall(fn, ...)
     vim.cmd.cd({curcwd , mods = mods})


### PR DESCRIPTION
When nvim-lint changes directories to run linters with a different cwd, vim.cmd.cd() prints the directory path. This causes unwanted notifications on every lint operation.

Added silent = true to the cd command modifiers to suppress this output.