### PR TITLE
Add csharpier linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Other dedicated linters that are built-in are:
 | [cppcheck][22]                         | `cppcheck`             |
 | [cpplint][cpplint]                     | `cpplint`              |
 | [credo][credo]                         | `credo`                |
+| [csharpier][csharpier]                 | `csharpier`            |
 | [dialyxir][dialyxir]                   | `dialyxir`             |
 | [cspell][36]                           | `cspell`               |
 | [cue][cue]                             | `cue`                  |
@@ -609,6 +610,7 @@ vimcats -t -f lua/lint.lua lua/lint/parser.lua > doc/lint.txt
 [lacheck]: https://www.ctan.org/tex-archive/support/lacheck
 [luac]: https://www.lua.org/manual/5.1/luac.html
 [credo]: https://github.com/rrrene/credo
+[csharpier]: https://github.com/belav/csharpier
 [dialyxir]: https://github.com/jeremyjh/dialyxir
 [ghdl]: https://github.com/ghdl/ghdl
 [gitleaks]: https://github.com/gitleaks/gitleaks

--- a/lua/lint/linters/csharpier.lua
+++ b/lua/lint/linters/csharpier.lua
@@ -1,0 +1,32 @@
+return {
+  cmd = 'csharpier',
+  -- `csharpier check` with stdin behaves like `format` and always exits 0,
+  -- so the file on disk is checked instead (requires csharpier >= 1.0)
+  stdin = false,
+  append_fname = true,
+  args = { 'check', '--no-msbuild-check' },
+  stream = 'stderr',
+  ignore_exitcode = true,
+  parser = function(output)
+    if not output:find('Was not formatted', 1, true) then
+      return {}
+    end
+    local lnum = tonumber(output:match('Expected: Around Line (%d+)')) or 1
+    local message = 'File is not formatted'
+    local expected = output:match('%-%-%-+ Expected: Around Line %d+ %-%-%-+\n(.-)\n%s*%-%-%-+ Actual:')
+    if expected then
+      -- csharpier indents the snippet by two spaces for display; strip it
+      expected = expected:gsub('^  ', ''):gsub('\n  ', '\n'):gsub('%s+$', '')
+      message = 'Replace by:\n' .. expected
+    end
+    return {
+      {
+        lnum = lnum - 1,
+        col = 0,
+        severity = vim.diagnostic.severity.WARN,
+        source = 'csharpier',
+        message = message,
+      },
+    }
+  end,
+}

--- a/spec/csharpier_spec.lua
+++ b/spec/csharpier_spec.lua
@@ -1,0 +1,31 @@
+describe("linter.csharpier", function()
+  it("can parse the output of an unformatted file", function()
+    local parser = require("lint.linters.csharpier").parser
+    local result = parser([[
+Error ./Bad.cs - Was not formatted.
+  ----------------------------- Expected: Around Line 7 -----------------------------
+      {
+          var x = 1;
+      }
+  ----------------------------- Actual: Around Line 7 -----------------------------
+      {
+          var x=1;
+      }
+]])
+    assert.are.same(1, #result)
+    local expected = {
+      source = "csharpier",
+      message = "Replace by:\n    {\n        var x = 1;\n    }",
+      lnum = 6,
+      col = 0,
+      severity = vim.diagnostic.severity.WARN,
+    }
+    assert.are.same(expected, result[1])
+  end)
+
+  it("returns no diagnostics for a formatted file", function()
+    local parser = require("lint.linters.csharpier").parser
+    local result = parser("Checked 1 files in 100ms.\n")
+    assert.are.same({}, result)
+  end)
+end)


### PR DESCRIPTION
Adds [CSharpier](https://github.com/belav/csharpier) (the opinionated C# formatter, `cs` filetype) as a linter, reporting a WARN diagnostic when a file is not formatted.

## Notes on the implementation

- `csharpier check` only reports whether a file is formatted, plus a snippet of the expected formatting around the first difference. The parser emits a single diagnostic at the reported line with the expected snippet in the message (`Replace by:` + formatted code, visible in the diagnostic float).
- **stdin can't be used**: `csharpier check` with piped input silently behaves like `format` (prints formatted code, exits 0), so the file on disk is checked instead (`stdin = false`). Requires csharpier >= 1.0 (the 1.0 release changed the CLI from `dotnet-csharpier --check` to `csharpier check`).
- Findings go to **stderr** (stdout only carries a `Checked N files in Xms.` summary), and the exit code is 1 when unformatted, hence `stream = 'stderr'` and `ignore_exitcode = true`.
- `--no-msbuild-check` skips probing csproj files for a CSharpier.MsBuild version mismatch, which keeps the check fast and avoids spurious failures when linting a single buffer.

All output shapes were verified against csharpier 1.2.6. Spec included (`spec/csharpier_spec.lua`) covering the unformatted and clean cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)