### PR TITLE
Enable golangci-lint to run in subdirectories

### DIFF
--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -5,9 +5,37 @@ local severities = {
   convention = vim.diagnostic.severity.HINT,
 }
 
+local function with_cwd(cwd, fn, ...)
+  local curcwd = vim.fn.getcwd()
+
+  if curcwd == cwd then
+    return fn(...)
+  else
+    local mods = { noautocmd = true }
+    vim.cmd.cd({ cwd, mods = mods })
+    local ok, result = pcall(fn, ...)
+    vim.cmd.cd({ curcwd, mods = mods })
+    return ok, result
+  end
+end
+
+local getGoModLocation = function(filename)
+  local dir = vim.fn.fnamemodify(filename, ":h")
+  return with_cwd(dir, vim.fn.system, { "go", "env", "GOMOD" })
+end
+
+local getCwd = function(filename)
+  local ok, go_mod_location = getGoModLocation(filename)
+  if not ok or go_mod_location == "/dev/null" or go_mod_location == "" then
+    return nil
+  end
+
+  return vim.fn.fnamemodify(go_mod_location, ":h")
+end
+
 -- Gets the correct arguments to run based on the version of golangci-lint
-local getArgs = function()
-  local ok, version_info = pcall(vim.fn.system, { 'golangci-lint', 'version' })
+local getArgs = function(filename)
+  local ok, version_info = pcall(vim.fn.system, { "golangci-lint", "version" })
   if not ok then
     return
   end
@@ -17,96 +45,91 @@ local getArgs = function()
   -- the current buffer path to golangci-lint instead of it's parent directory to allow
   -- the buffer content to be linted, otherwise golangci-lint will raise an error
   local go_mod_location
-  ok, go_mod_location = pcall(vim.fn.system, { 'go', 'env', 'GOMOD' })
-  if not ok then
+  ok, go_mod_location = getGoModLocation(filename)
+  local filename_modifier = ":h"
+  if not ok or go_mod_location == nil then
     return
   end
-  local filename_modifier = ':h'
   -- Remove extra whitespace like newline characters
-  go_mod_location = go_mod_location:gsub('%s+', '')
+  go_mod_location = go_mod_location:gsub("%s+", "")
   -- No go.mod file was found, so just lint the buffer directly
-  if go_mod_location == '/dev/null' or go_mod_location == '' then
-    filename_modifier = ':p'
+  if go_mod_location == "/dev/null" or go_mod_location == "" then
+    filename_modifier = ":p"
   end
+
+  filename = vim.fn.fnamemodify(filename, filename_modifier)
 
   -- The golangci-lint install script and prebuilt binaries strip the v from the version
   --   tag so both strings must be checked
-  if string.find(version_info, 'version v1') or string.find(version_info, 'version 1') then
+  if string.find(version_info, "version v1") or string.find(version_info, "version 1") then
     return {
-      'run',
-      '--out-format',
-      'json',
-      '--issues-exit-code=0',
-      '--show-stats=false',
-      '--print-issued-lines=false',
-      '--print-linter-name=false',
-      function()
-        return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), filename_modifier)
-      end
+      "run",
+      "--out-format",
+      "json",
+      "--issues-exit-code=0",
+      "--show-stats=false",
+      "--print-issued-lines=false",
+      "--print-linter-name=false",
+      filename,
     }
   end
 
   -- Omit --path-mode=abs, as it was added on v2.1.0
   -- Make sure it won't break v2.0.{0,1,2}
-  if string.find(version_info, 'version v2.0.') or string.find(version_info, 'version 2.0.') then
+  if string.find(version_info, "version v2.0.") or string.find(version_info, "version 2.0.") then
     -- If the linter is not working as expected, users should explicitly add
     -- `run.relative-path-mode: wd` to their .golangci.yaml as a workaround to preserve the previous behavior.
     -- Prior to v2.0.0, the default for `run.relative-path-mode` was "wd".
     -- See: https://golangci-lint.run/product/migration-guide/#runrelative-path-mode
 
     return {
-      'run',
-      '--output.json.path=stdout',
+      "run",
+      "--output.json.path=stdout",
       -- Overwrite values possibly set in .golangci.yml
-      '--output.text.path=',
-      '--output.tab.path=',
-      '--output.html.path=',
-      '--output.checkstyle.path=',
-      '--output.code-climate.path=',
-      '--output.junit-xml.path=',
-      '--output.teamcity.path=',
-      '--output.sarif.path=',
-      '--issues-exit-code=0',
-      '--show-stats=false',
-      function()
-        return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), filename_modifier)
-      end,
+      "--output.text.path=",
+      "--output.tab.path=",
+      "--output.html.path=",
+      "--output.checkstyle.path=",
+      "--output.code-climate.path=",
+      "--output.junit-xml.path=",
+      "--output.teamcity.path=",
+      "--output.sarif.path=",
+      "--issues-exit-code=0",
+      "--show-stats=false",
+      filename,
     }
   end
 
   return {
-    'run',
-    '--output.json.path=stdout',
+    "run",
+    "--output.json.path=stdout",
     -- Overwrite values possibly set in .golangci.yml
-    '--output.text.path=',
-    '--output.tab.path=',
-    '--output.html.path=',
-    '--output.checkstyle.path=',
-    '--output.code-climate.path=',
-    '--output.junit-xml.path=',
-    '--output.teamcity.path=',
-    '--output.sarif.path=',
-    '--issues-exit-code=0',
-    '--show-stats=false',
+    "--output.text.path=",
+    "--output.tab.path=",
+    "--output.html.path=",
+    "--output.checkstyle.path=",
+    "--output.code-climate.path=",
+    "--output.junit-xml.path=",
+    "--output.teamcity.path=",
+    "--output.sarif.path=",
+    "--issues-exit-code=0",
+    "--show-stats=false",
     -- Get absolute path of the linted file
-    '--path-mode=abs',
-    function()
-      return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), filename_modifier)
-    end,
+    "--path-mode=abs",
+    filename,
   }
 end
 
-return {
-  cmd = 'golangci-lint',
+local default_options = {
+  cmd = "golangci-lint",
   append_fname = false,
-  args = getArgs(),
-  stream = 'stdout',
+  stream = "stdout",
   parser = function(output, bufnr, cwd)
-    if output == '' then
+    if output == "" then
       return {}
     end
     local decoded = vim.json.decode(output)
-    if decoded["Issues"] == nil or type(decoded["Issues"]) == 'userdata' then
+    if decoded["Issues"] == nil or type(decoded["Issues"]) == "userdata" then
       return {}
     end
 
@@ -135,5 +158,13 @@ return {
       end
     end
     return diagnostics
-  end
+  end,
 }
+
+return function()
+  local filename = vim.api.nvim_buf_get_name(0)
+  local options = default_options
+  options.cwd = getCwd(filename)
+  options.args = getArgs(filename)
+  return options
+end

--- a/lua/lint/linters/golangcilint.lua
+++ b/lua/lint/linters/golangcilint.lua
@@ -20,22 +20,22 @@ local function with_cwd(cwd, fn, ...)
 end
 
 local getGoModLocation = function(filename)
-  local dir = vim.fn.fnamemodify(filename, ":h")
-  return with_cwd(dir, vim.fn.system, { "go", "env", "GOMOD" })
+  local dir = vim.fn.fnamemodify(filename, ':h')
+  return with_cwd(dir, vim.fn.system, { 'go', 'env', 'GOMOD' })
 end
 
 local getCwd = function(filename)
   local ok, go_mod_location = getGoModLocation(filename)
-  if not ok or go_mod_location == "/dev/null" or go_mod_location == "" then
+  if not ok or go_mod_location == '/dev/null' or go_mod_location == '' then
     return nil
   end
 
-  return vim.fn.fnamemodify(go_mod_location, ":h")
+  return vim.fn.fnamemodify(go_mod_location, ':h')
 end
 
 -- Gets the correct arguments to run based on the version of golangci-lint
 local getArgs = function(filename)
-  local ok, version_info = pcall(vim.fn.system, { "golangci-lint", "version" })
+  local ok, version_info = pcall(vim.fn.system, { 'golangci-lint', 'version' })
   if not ok then
     return
   end
@@ -46,101 +46,101 @@ local getArgs = function(filename)
   -- the buffer content to be linted, otherwise golangci-lint will raise an error
   local go_mod_location
   ok, go_mod_location = getGoModLocation(filename)
-  local filename_modifier = ":h"
+  local filename_modifier = ':h'
   if not ok or go_mod_location == nil then
     return
   end
   -- Remove extra whitespace like newline characters
-  go_mod_location = go_mod_location:gsub("%s+", "")
+  go_mod_location = go_mod_location:gsub('%s+', '')
   -- No go.mod file was found, so just lint the buffer directly
-  if go_mod_location == "/dev/null" or go_mod_location == "" then
-    filename_modifier = ":p"
+  if go_mod_location == '/dev/null' or go_mod_location == '' then
+    filename_modifier = ':p'
   end
 
   filename = vim.fn.fnamemodify(filename, filename_modifier)
 
   -- The golangci-lint install script and prebuilt binaries strip the v from the version
   --   tag so both strings must be checked
-  if string.find(version_info, "version v1") or string.find(version_info, "version 1") then
+  if string.find(version_info, 'version v1') or string.find(version_info, 'version 1') then
     return {
-      "run",
-      "--out-format",
-      "json",
-      "--issues-exit-code=0",
-      "--show-stats=false",
-      "--print-issued-lines=false",
-      "--print-linter-name=false",
+      'run',
+      '--out-format',
+      'json',
+      '--issues-exit-code=0',
+      '--show-stats=false',
+      '--print-issued-lines=false',
+      '--print-linter-name=false',
       filename,
     }
   end
 
   -- Omit --path-mode=abs, as it was added on v2.1.0
   -- Make sure it won't break v2.0.{0,1,2}
-  if string.find(version_info, "version v2.0.") or string.find(version_info, "version 2.0.") then
+  if string.find(version_info, 'version v2.0.') or string.find(version_info, 'version 2.0.') then
     -- If the linter is not working as expected, users should explicitly add
     -- `run.relative-path-mode: wd` to their .golangci.yaml as a workaround to preserve the previous behavior.
-    -- Prior to v2.0.0, the default for `run.relative-path-mode` was "wd".
+    -- Prior to v2.0.0, the default for `run.relative-path-mode` was 'wd'.
     -- See: https://golangci-lint.run/product/migration-guide/#runrelative-path-mode
 
     return {
-      "run",
-      "--output.json.path=stdout",
+      'run',
+      '--output.json.path=stdout',
       -- Overwrite values possibly set in .golangci.yml
-      "--output.text.path=",
-      "--output.tab.path=",
-      "--output.html.path=",
-      "--output.checkstyle.path=",
-      "--output.code-climate.path=",
-      "--output.junit-xml.path=",
-      "--output.teamcity.path=",
-      "--output.sarif.path=",
-      "--issues-exit-code=0",
-      "--show-stats=false",
+      '--output.text.path=',
+      '--output.tab.path=',
+      '--output.html.path=',
+      '--output.checkstyle.path=',
+      '--output.code-climate.path=',
+      '--output.junit-xml.path=',
+      '--output.teamcity.path=',
+      '--output.sarif.path=',
+      '--issues-exit-code=0',
+      '--show-stats=false',
       filename,
     }
   end
 
   return {
-    "run",
-    "--output.json.path=stdout",
+    'run',
+    '--output.json.path=stdout',
     -- Overwrite values possibly set in .golangci.yml
-    "--output.text.path=",
-    "--output.tab.path=",
-    "--output.html.path=",
-    "--output.checkstyle.path=",
-    "--output.code-climate.path=",
-    "--output.junit-xml.path=",
-    "--output.teamcity.path=",
-    "--output.sarif.path=",
-    "--issues-exit-code=0",
-    "--show-stats=false",
+    '--output.text.path=',
+    '--output.tab.path=',
+    '--output.html.path=',
+    '--output.checkstyle.path=',
+    '--output.code-climate.path=',
+    '--output.junit-xml.path=',
+    '--output.teamcity.path=',
+    '--output.sarif.path=',
+    '--issues-exit-code=0',
+    '--show-stats=false',
     -- Get absolute path of the linted file
-    "--path-mode=abs",
+    '--path-mode=abs',
     filename,
   }
 end
 
 local default_options = {
-  cmd = "golangci-lint",
+  cmd = 'golangci-lint',
   append_fname = false,
-  stream = "stdout",
+  stream = 'stdout',
   parser = function(output, bufnr, cwd)
-    if output == "" then
+    if output == '' then
       return {}
     end
     local decoded = vim.json.decode(output)
-    if decoded["Issues"] == nil or type(decoded["Issues"]) == "userdata" then
+    if decoded['Issues'] == nil or type(decoded['Issues']) == 'userdata' then
       return {}
     end
 
     local diagnostics = {}
-    for _, item in ipairs(decoded["Issues"]) do
+    for _, item in ipairs(decoded['Issues']) do
       local curfile = vim.api.nvim_buf_get_name(bufnr)
-      local curfile_abs = vim.fn.fnamemodify(curfile, ":p")
+      local curfile_abs = vim.fn.fnamemodify(curfile, ':p')
       local curfile_norm = vim.fs.normalize(curfile_abs)
 
-      local lintedfile = cwd .. "/" .. item.Pos.Filename
-      local lintedfile_abs = vim.fn.fnamemodify(lintedfile, ":p")
+      local lintedfile = cwd .. '/' .. item.Pos.Filename
+      local lintedfile_abs = vim.fn.fnamemodify(lintedfile, ':p')
       local lintedfile_norm = vim.fs.normalize(lintedfile_abs)
 
       if curfile_norm == vim.fs.normalize(item.Pos.Filename) or curfile_norm == lintedfile_norm then


### PR DESCRIPTION
I have this setup for a monrepo:

project/
-> app/ -- a fllutter project
-> backend/ -- a go project

As a result I can't tun golangcilint from nvim directly with this plugin.

This PR fixes that