### PR TITLE
oelint: Add config file support

### DIFF
--- a/lua/lint/linters/oelint-adv.lua
+++ b/lua/lint/linters/oelint-adv.lua
@@ -7,21 +7,33 @@ local severity_map = {
   ['info'] = vim.diagnostic.severity.INFO,
 }
 
-return {
-  cmd = 'oelint-adv',
-  stdin = false,
-  args = {
-    '--quiet',
-    '--messageformat={path}:{line}:{severity}:{id}:{msg}',
-  },
-  env = {
-    ["NO_COLOR"] = "1",
-    ["HOME"] = os.getenv("HOME"),
-  },
-  ignore_exitcode = true,
-  stream = 'stderr',
-  parser = require('lint.parser').from_pattern(
-    pattern, groups, severity_map,
-    { ['source'] = 'oelint-adv' }
-  ),
-}
+local function find_config()
+  local conf = vim.fs.find('.oelint.cfg', {
+    upward = true,
+    stop = vim.fs.dirname(vim.loop.os_homedir()),
+    path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),
+  })
+  return conf[1] or ''
+end
+
+return function()
+  return {
+    cmd = 'oelint-adv',
+    stdin = false,
+    args = {
+      '--quiet',
+      '--messageformat={path}:{line}:{severity}:{id}:{msg}',
+    },
+    env = {
+      ["NO_COLOR"] = "1",
+      ["HOME"] = os.getenv("HOME"),
+      ["OELINT_CONFIG"] = find_config(),
+    },
+    ignore_exitcode = true,
+    stream = 'stderr',
+    parser = require('lint.parser').from_pattern(
+      pattern, groups, severity_map,
+      { ['source'] = 'oelint-adv' }
+    ),
+  }
+end


### PR DESCRIPTION
Adds support for local `.oelint.cfg` config files ([docs](https://github.com/priv-kweihmann/oelint-adv#configuration-file)).