### PR TITLE
feat(linters): Add bloc linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Other dedicated linters that are built-in are:
 | [bash][bash]                           | `bash`                 |
 | [bean-check][bean-check]               | `bean_check`           |
 | [biomejs][biomejs]                     | `biomejs`              |
+| [bloc][bloc]                           | `bloc`                 |
 | [blocklint][blocklint]                 | `blocklint`            |
 | [buf_lint][buf_lint]                   | `buf_lint`             |
 | [buildifier][buildifier]               | `buildifier`           |
@@ -783,3 +784,4 @@ vimcats -t -f lua/lint.lua lua/lint/parser.lua > doc/lint.txt
 [bubblewrap]: https://github.com/containers/bubblewrap
 [unmake]: https://github.com/mcandre/unmake
 [detekt]: https://detekt.dev/
+[bloc]: https://bloclibrary.dev/

--- a/lua/lint/linters/bloc.lua
+++ b/lua/lint/linters/bloc.lua
@@ -1,28 +1,34 @@
 local linter_name = "bloc"
 
 -- See https://bloclibrary.dev/lint/
-local pattern = "(%w+)%[([%w_]+)%]:%s*(.-)\n%s*%-%->%s*.-:(%d+)"
+local pattern = "(%w+)%[([%w_]+)%]:%s*(.-)\n%s*%-%->%s*.-:(%d+)\n%s*|\n%s*|.-\n%s*| (%s*)(%^+)"
 
 -- See https://bloclibrary.dev/lint/customizing-rules/#customizing-rule-severity
 local severity_map = {
   error = vim.diagnostic.severity.ERROR,
   warning = vim.diagnostic.severity.WARN,
   info = vim.diagnostic.severity.INFO,
-  hint = vim.diagnostic.severity.HINT,
 }
 
 ---@type lint.parse
-local function parse_bloc_output(output)
+local function parse_bloc_output(output, bufnr)
   local diagnostics = {}
 
-  for severity_str, code, msg, lnum in output:gmatch(pattern) do
+  for sev_str, code, msg, line_number, spaces, carets in output:gmatch(pattern) do
+    local col = #spaces
+    local end_col = col + #carets
+    local lnum = tonumber(line_number) - 1
+    local severity = severity_map[sev_str] or vim.diagnostic.severity.WARN
+
     table.insert(diagnostics, {
+      bufnr = bufnr,
       source = linter_name,
       code = code,
       message = msg,
-      severity = severity_map[severity_str] or vim.diagnostic.severity.WARN,
-      lnum = tonumber(lnum) - 1,
-      col = 0,
+      severity = severity,
+      lnum = lnum,
+      col = col,
+      end_col = end_col,
     })
   end
 

--- a/lua/lint/linters/bloc.lua
+++ b/lua/lint/linters/bloc.lua
@@ -1,0 +1,42 @@
+local linter_name = "bloc"
+
+-- See https://bloclibrary.dev/lint/
+local pattern = "(%w+)%[([%w_]+)%]:%s*(.-)\n%s*%-%->%s*.-:(%d+)"
+
+-- See https://bloclibrary.dev/lint/customizing-rules/#customizing-rule-severity
+local severity_map = {
+  error = vim.diagnostic.severity.ERROR,
+  warning = vim.diagnostic.severity.WARN,
+  info = vim.diagnostic.severity.INFO,
+  hint = vim.diagnostic.severity.HINT,
+}
+
+---@type lint.parse
+local function parse_bloc_output(output)
+  local diagnostics = {}
+
+  for severity_str, code, msg, lnum in output:gmatch(pattern) do
+    table.insert(diagnostics, {
+      source = linter_name,
+      code = code,
+      message = msg,
+      severity = severity_map[severity_str] or vim.diagnostic.severity.WARN,
+      lnum = tonumber(lnum) - 1,
+      col = 0,
+    })
+  end
+
+  return diagnostics
+end
+
+---@type lint.Linter
+return {
+  name = linter_name,
+  cmd = "bloc",
+  args = { "lint" },
+  stdin = false,
+  append_fname = true,
+  stream = "stdout",
+  ignore_exitcode = true,
+  parser = parse_bloc_output,
+}

--- a/spec/bloc_spec.lua
+++ b/spec/bloc_spec.lua
@@ -1,0 +1,82 @@
+describe("linter.bloc", function()
+  it("should ignore empty output", function()
+    local parser = require("lint.linters.bloc").parser
+
+    assert.are.same({}, parser("", vim.api.nvim_get_current_buf()))
+    assert.are.same({}, parser("  ", vim.api.nvim_get_current_buf()))
+  end)
+
+  it("should parse the output", function()
+    local parser = require("lint.linters.bloc").parser
+    local bufnr = vim.uri_to_bufnr("file:///lib/example.dart")
+
+    local output = [[
+warning[avoid_public_bloc_methods]: Avoid public methods on bloc instances.
+ --> lib/example.dart:16
+  |
+  |   void publicMethod() {
+  |        ^^^^^^^^^^^^
+  = hint: Prefer notifying bloc instances via `add`.
+ docs: https://bloclibrary.dev/lint-rules/avoid_public_bloc_methods
+
+error[avoid_public_fields]: Avoid public fields.
+ --> lib/example.dart:8
+  |
+  |   String publicField = "public";
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = hint: Prefer using the `state` to hold all public fields.
+ docs: https://bloclibrary.dev/lint-rules/avoid_public_fields
+
+info[prefer_file_naming_conventions]: Prefer following file naming conventions.
+ --> lib/example.dart:7
+  |
+  | class WrongNameBloc extends Bloc<ExampleEvent, String> {
+  |       ^^^^^^^^^^^^^
+  = hint: Prefer moving WrongNameBloc into wrong_name_bloc.dart.dart
+ docs: https://bloclibrary.dev/lint-rules/prefer_file_naming_conventions
+
+3 issues found
+Analyzed 4 files
+]]
+
+    local result = parser(output, bufnr)
+    assert.are.same(3, #result)
+
+    local expected_error = {
+      bufnr = bufnr,
+      source = "bloc",
+      code = "avoid_public_bloc_methods",
+      message = "Avoid public methods on bloc instances.",
+      severity = vim.diagnostic.severity.WARN,
+      lnum = 15,
+      col = 7,
+      end_col = 19,
+    }
+
+    local expected_warning = {
+      bufnr = bufnr,
+      source = "bloc",
+      code = "avoid_public_fields",
+      message = "Avoid public fields.",
+      severity = vim.diagnostic.severity.ERROR,
+      lnum = 7,
+      col = 2,
+      end_col = 32,
+    }
+
+    local expected_info = {
+      bufnr = bufnr,
+      source = "bloc",
+      code = "prefer_file_naming_conventions",
+      message = "Prefer following file naming conventions.",
+      severity = vim.diagnostic.severity.INFO,
+      lnum = 6,
+      col = 6,
+      end_col = 19,
+    }
+
+    assert.are.same(expected_error, result[1])
+    assert.are.same(expected_warning, result[2])
+    assert.are.same(expected_info, result[3])
+  end)
+end)


### PR DESCRIPTION
Add support for the bloc linter.

[Bloc](https://bloclibrary.dev/) is a Dart state management library which provides its own [linting tool](https://bloclibrary.dev/lint/). To support this, I'm using the CLI tool and parsing the output to generate diagnostics. I also tested this configuration on my own Flutter projects.