### PR TITLE
feat: add droast as linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Other dedicated linters that are built-in are:
 | [DirectX Shader Compiler][dxc]         | `dxc`                  |
 | [djlint][djlint]                       | `djlint`               |
 | [dotenv-linter][dotenv-linter]         | `dotenv_linter`        |
+| [droast][droast]                       | `droast`               |
 | [editorconfig-checker][ec]             | `editorconfig-checker` |
 | [erb-lint][erb-lint]                   | `erb_lint`             |
 | [ESLint][25]                           | `eslint`               |
@@ -783,3 +784,4 @@ vimcats -t -f lua/lint.lua lua/lint/parser.lua > doc/lint.txt
 [bubblewrap]: https://github.com/containers/bubblewrap
 [unmake]: https://github.com/mcandre/unmake
 [detekt]: https://detekt.dev/
+[droast]: https://github.com/immanuwell/dockerfile-roast

--- a/lua/lint/linters/droast.lua
+++ b/lua/lint/linters/droast.lua
@@ -1,0 +1,51 @@
+local severity_map = {
+  ERROR = vim.diagnostic.severity.ERROR,
+  WARN = vim.diagnostic.severity.WARN,
+  INFO = vim.diagnostic.severity.INFO,
+}
+local function diagnostic_from_finding(finding)
+  local line = math.max((finding.line or 1) - 1, 0)
+  local column = math.max((finding.column or 1) - 1, 0)
+  local diagnostic = {
+    lnum = line,
+    col = column,
+    severity = severity_map[finding.severity] or vim.diagnostic.severity.WARN,
+    source = "droast",
+    code = finding.rule,
+    message = string.format("[%s] %s", finding.rule, finding.message),
+  }
+  if finding.end_line then
+    diagnostic.end_lnum = math.max(finding.end_line - 1, line)
+  end
+  if finding.end_column then
+    diagnostic.end_col = math.max(finding.end_column - 1, column)
+  end
+  return diagnostic
+end
+
+return {
+  cmd = "droast",
+  stdin = false,
+  append_fname = true,
+  args = {
+    "--format",
+    "json",
+    "--no-roast",
+    "--no-fail",
+    "--check-dockerignore=false",
+  },
+  stream = "both",
+  ignore_exitcode = true,
+  env = nil,
+  parser = function(output)
+    if output == "" then
+      return {}
+    end
+    local decoded = vim.json.decode(output)
+    local diagnostics = {}
+    for _, finding in ipairs(decoded.findings or {}) do
+      table.insert(diagnostics, diagnostic_from_finding(finding))
+    end
+    return diagnostics
+  end,
+}

--- a/lua/lint/linters/droast.lua
+++ b/lua/lint/linters/droast.lua
@@ -33,7 +33,7 @@ return {
     "json",
     "--no-roast",
     "--no-fail",
-    "--check-dockerignore=false",
+    "--check-ignorefile=false",
   },
   stream = "both",
   ignore_exitcode = true,

--- a/lua/lint/linters/droast.lua
+++ b/lua/lint/linters/droast.lua
@@ -3,6 +3,7 @@ local severity_map = {
   WARN = vim.diagnostic.severity.WARN,
   INFO = vim.diagnostic.severity.INFO,
 }
+
 local function diagnostic_from_finding(finding)
   local line = math.max((finding.line or 1) - 1, 0)
   local column = math.max((finding.column or 1) - 1, 0)


### PR DESCRIPTION
Droast linter: https://github.com/immanuwell/dockerfile-roast
This implementation references https://github.com/immanuwell/droast.nvim/blob/main/lua/droast/init.lua, the official plugin for using droast in neovim

<img width="634" height="610" alt="image" src="https://github.com/user-attachments/assets/509f68bf-d0ae-4705-8e83-552e82e22540" />

<img width="1063" height="195" alt="image" src="https://github.com/user-attachments/assets/401379aa-96de-4950-b7f9-26cc62cb1b1b" />

