### PR TITLE
Fix fortitude.lua parsing of line positions

### DIFF
--- a/lua/lint/linters/fortitude.lua
+++ b/lua/lint/linters/fortitude.lua
@@ -28,8 +28,8 @@ return {
     for _, item in ipairs(output_decoded) do
       table.insert(diagnostics, {
         bufnr = bufnr,
-        lnum = item.location.row - 1,
-        end_lnum = item.end_location.row - 1,
+        lnum = item.location.line - 1,
+        end_lnum = item.end_location.line - 1,
         col = item.location.column - 1,
         end_col = item.end_location.column - 1,
         severity = severity_map[item.code:match("^(%a+)(%d+)")] or vim.diagnostic.severity.WARN,

--- a/spec/fortitude_spec.lua
+++ b/spec/fortitude_spec.lua
@@ -16,7 +16,7 @@ describe("linter.fortitude", function()
     "code": "C003",
     "end_location": {
       "column": 18,
-      "row": 3
+      "line": 3
     },
     "filename": "/home/user/documents/somefortranfile.f90",
     "fix": {
@@ -26,11 +26,11 @@ describe("linter.fortitude", function()
           "content": " (type, external)",
           "end_location": {
             "column": 18,
-            "row": 3
+            "line": 3
           },
           "location": {
             "column": 18,
-            "row": 3
+            "line": 3
           }
         }
       ],
@@ -38,7 +38,7 @@ describe("linter.fortitude", function()
     },
     "location": {
       "column": 5,
-      "row": 3
+      "line": 3
     },
     "message": "'implicit none' missing 'external'"
   },
@@ -46,13 +46,13 @@ describe("linter.fortitude", function()
     "code": "E001",
     "end_location": {
       "column": 14,
-      "row": 7
+      "line": 7
     },
     "filename": "/home/user/documents/somefortranfile.f90",
     "fix": null,
     "location": {
       "column": 13,
-      "row": 7
+      "line": 7
     },
     "message": "Syntax error"
   }


### PR DESCRIPTION
fortitude linter output uses 'line' not 'row'

changed: 
item.location.row --> item.location.line

Corrected the error for me